### PR TITLE
Apply scrap-your-typeclasses to Purescript JSON encoding

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
     "url": "git://github.com/ccap/purescript-ccap-codegen.git"
   },
   "dependencies": {
+    "purescript-argonaut-codecs": "^6.0.0",
     "purescript-boxes": "^1.0.1",
     "purescript-debug": "^4.0.0",
     "purescript-generics-rep": "^6.1.1",

--- a/src/Ccap/Codegen/Purescript.purs
+++ b/src/Ccap/Codegen/Purescript.purs
@@ -5,26 +5,18 @@ module Ccap.Codegen.Purescript
 
 import Prelude
 
-import Ccap.Codegen.Shared (OutputSpec, indented)
+import Ccap.Codegen.Shared (Emit, OutputSpec, emit, indented)
 import Ccap.Codegen.Types (Module(..), Primitive(..), RecordProp(..), TopType(..), Type(..), TypeDecl(..))
-import Control.Monad.Writer (Writer, runWriter, tell)
+import Control.Monad.Writer (runWriter, tell)
 import Data.Array ((:))
 import Data.Array as Array
-import Data.Map as Map
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe, fromMaybe)
 import Data.String (Pattern(..))
 import Data.String as String
-import Data.Traversable (traverse)
+import Data.Traversable (for, traverse)
 import Data.Tuple (Tuple(..))
-import Text.PrettyPrint.Boxes (Box, char, emptyBox, hsep, render, text, vcat, vsep, (//), (<<+>>), (<<>>))
-import Text.PrettyPrint.Boxes (bottom, left) as Boxes
-
-type Imports = Array String
-
-type Emit = Writer Imports
-
-emit :: forall a. Array String -> a -> Emit a
-emit imports a = map (const a) (tell imports)
+import Text.PrettyPrint.Boxes (Box, char, hcat, hsep, render, text, vcat, vsep, (//), (<<+>>), (<<>>))
+import Text.PrettyPrint.Boxes (bottom, left, top) as Boxes
 
 prettyPrint :: String -> Array Module -> String
 prettyPrint module_ modules =
@@ -66,64 +58,80 @@ splitType s = do
   pure $ { prefix, t }
 
 typeDecl :: TypeDecl -> Emit Box
-typeDecl (TypeDecl name tt _) =
+typeDecl (TypeDecl name tt annots) =
   let dec kw = text kw <<+>> text name <<+>> char '='
   in case tt of
-    Type t ->
-      tyType t <#> (dec "type" <<+>> _)
-    Wrap t wo ->
-      case Map.lookup "purs" wo of
-        Nothing ->
-          tyType t <#> (\ty ->
-            dec "newtype" <<+>> text name <<+>> ty
-              // newtypeInstances name
-              // otherInstances name)
-        Just { typ, wrap, unwrap } ->
-          fromMaybe { prefix: "?missingPrefix", t: typ } (splitType typ)
-            # externalType <#> (dec "type" <<+>> _)
-    Record props ->
-      record props <#> \p -> dec "type" // indented p
-    Sum vs -> pure do
-      dec "data"
-        // indented (hsep 1 Boxes.bottom $ vcat Boxes.left <$> [ Array.drop 1 vs <#> \_ -> char '|',  vs <#> text ])
-        // otherInstances name
-        // encodeJsonSum name vs
-        // decodeJsonSum name vs
+    Type t -> do
+      ty <- tyType t
+      j <- jsonCodec t
+      pure $ (dec "type" <<+>> ty)
+        // jsonCodecTypeDecl name
+        // (text "jsonCodec_" <<>> text name <<>> text " = " <<>> j)
+    Wrap t _ -> do
+      other <- otherInstances name
+      ty <- tyType t
+      j <- topTypeJsonCodec name tt
+      newtype_ <- newtypeInstances name
+      pure $
+        dec "newtype" <<+>> text name <<+>> ty
+          // newtype_
+          // jsonCodecTypeDecl name
+          // (text "jsonCodec_" <<>> text name <<>> text " = " <<>> j)
+          // other
+    Record props -> do
+      recordDecl <- record props <#> \p -> dec "type" // indented p
+      codec <- topTypeJsonCodec name tt
+      pure $
+        recordDecl
+          // jsonCodecTypeDecl name
+          // (text "jsonCodec_" <<>> text name <<>> text " = ")
+          // indented codec
+    Sum vs -> do
+      other <- otherInstances name
+      codec <- topTypeJsonCodec name tt
+      pure $
+        dec "data"
+          // indented (hsep 1 Boxes.bottom $ vcat Boxes.left <$> [ Array.drop 1 vs <#> \_ -> char '|',  vs <#> text ])
+          // other
+          // jsonCodecTypeDecl name
+          // (text "jsonCodec_" <<>> text name <<>> text " = ")
+          // indented codec
 
-encodeJsonSum :: String -> Array String -> Box
-encodeJsonSum name vs =
-  text ("instance encodeJson" <> name <> " :: EncodeJson " <> name <> " where")
-    // indented (text "encodeJson s = encodeJson $ case s of" // indented branches)
+sumJsonCodec :: String -> Array String -> Emit Box
+sumJsonCodec name vs = do
+  tell
+    [ "Data.Either (Either(..))"
+    ]
+  let write = text "write: case _ of"
+                // indented (branches writeBranch)
+      read = text "read: case _ of"
+                // indented (branches readBranch // fallthrough)
+  pure $ text "Runtime.composeCodec"
+          // indented (delimitedLiteral Vert '{' '}' [ read, write ] // text "Runtime.jsonCodec_string")
   where
-    branches = vcat Boxes.left (vs <#> branch)
-    branch v = text v <<+>> text "->" <<+>> text (show v)
+    branches branch = vcat Boxes.left (vs <#> branch)
+    writeBranch v = text v <<+>> text "->" <<+>> text (show v)
+    readBranch v = text (show v) <<+>> text "-> Right" <<+>> text v
+    fallthrough = text $ "s -> Left $ \"Invalid value \" <> show s <> \" for " <> name <> "\""
 
-decodeJsonSum :: String -> Array String -> Box
-decodeJsonSum name vs =
-  text ("instance decodeJson" <> name <> " :: DecodeJson " <> name <> " where")
-    // indented (text "decodeJson j = do" // indented (decodeString // decodeBranches))
-  where
-    decodeString = text "s <- decodeJson"
-    decodeBranches =
-      text "case s of"
-        // indented (branches // fallthrough)
-    branches = vcat Boxes.left (vs <#> branch)
-    branch v = text (show v) <<+>> text "-> Right" <<+>> text v
-    fallthrough = text $ "_ -> Left \"Invalid value \" <> show s <> \"for " <> name <> "\""
-
-newtypeInstances :: String -> Box
+newtypeInstances :: String -> Emit Box
 newtypeInstances name =
-  text ("derive instance newtype" <> name <> " :: Newtype " <> name <> " _")
-    // text ("derive newtype instance decodeJson" <> name <> " :: DecodeJson " <> name <> " _")
-    // text ("derive newtype instance encodeJson" <> name <> " :: EncodeJson " <> name <> " _")
+  emit
+    [ "Data.Newtype (class Newtype)" ]
+    $ text ("derive instance newtype" <> name <> " :: Newtype " <> name <> " _")
 
-otherInstances :: String -> Box
+otherInstances :: String -> Emit Box
 otherInstances name =
-  text ("derive instance eq" <> name <> " :: Eq " <> name)
-    // text ("derive instance ord" <> name <> " :: Ord " <> name)
-    // text ("derive instance generic" <> name <> " :: Generic " <> name <> " _")
-    // text ("instance show" <> name <> " :: Show " <> name <> " where")
-    // indented (text "show a = genericShow a")
+  emit
+    [ "Prelude"
+    , "Data.Generic.Rep (class Generic)"
+    , "Data.Generic.Rep.Show (genericShow)"
+    ]
+    $ text ("derive instance eq" <> name <> " :: Eq " <> name)
+        // text ("derive instance ord" <> name <> " :: Ord " <> name)
+        // text ("derive instance generic" <> name <> " :: Generic " <> name <> " _")
+        // text ("instance show" <> name <> " :: Show " <> name <> " where")
+        // indented (text "show a = genericShow a")
 
 tyType :: Type -> Emit Box
 tyType =
@@ -136,14 +144,97 @@ tyType =
     Array t -> wrap "Array" t
     Option t -> tell (pure "Data.Maybe (Maybe)") >>= const (wrap "Maybe" t)
 
+emitRuntime :: Box -> Emit Box
+emitRuntime b = emit [ "Ccap.Codegen.Runtime as Runtime" ] b
+
+topTypeJsonCodec :: String -> TopType -> Emit Box
+topTypeJsonCodec name =
+  case _ of
+    Type ty -> jsonCodec ty
+    Wrap ty _ -> do
+      i <- jsonCodec ty
+      emitRuntime $ text "Runtime.codec_newtype" <<+>> char '(' <<>> i <<>> text ")"
+    Record props -> recordJsonCodec props
+    Sum vs -> sumJsonCodec name vs
+
+jsonCodec :: Type -> Emit Box
+jsonCodec ty =
+  case ty of
+    Primitive p ->
+      case p of
+        PBoolean -> emitRuntime (text "Runtime.jsonCodec_boolean")
+        PInt -> emitRuntime (text "Runtime.jsonCodec_int")
+        PDecimal -> emitRuntime (text "Runtime.jsonCodec_decimal")
+        PString -> emitRuntime (text "Runtime.jsonCodec_string")
+    Array t_ -> map parens (tycon "array" t_)
+    Option t_ -> map parens (tycon "maybe" t_)
+    Ref _ s -> pure $ text ("jsonCodec_" <> s)
+  where
+    tycon which t_ = do
+      inner <- jsonCodec t_
+      emitRuntime $ text "Runtime.jsonCodec_" <<>> text which <<+>> inner
+
+parens :: Box -> Box
+parens b = char '(' <<>> b <<>> char ')'
+
+jsonCodecTypeDecl :: String -> Box
+jsonCodecTypeDecl name =
+  text "jsonCodec_" <<>> text name <<+>> text ":: Runtime.JsonCodec" <<+>> text name
+
+data DelimitedLiteralDir = Vert | Horiz
+
+delimitedLiteral
+  :: DelimitedLiteralDir
+  -> Char
+  -> Char
+  -> Array Box
+  -> Box
+delimitedLiteral dir l r boxes =
+  let all = (Array.take 1 boxes <#> (char l <<+>> _))
+                  <> (Array.drop 1 boxes <#> (char ',' <<+>> _))
+  in case dir of
+       Vert -> vcat Boxes.left (all <> [ char r ])
+       Horiz -> hcat Boxes.top (all <> [ char ' ' <<>> char r ])
+
 record :: Array RecordProp -> Emit Box
 record props = do
-  let len = Array.length props
-      space = emptyBox 0 1
+  tell [ "Data.Tuple (Tuple(..))" ]
   types <- (\(RecordProp _ t) -> tyType t) `traverse` props
   let labels = props <#> \(RecordProp name _) -> text name <<+>> text "::"
-      columns =
-        [ Array.snoc ('{' : (Array.drop 1 props <#> const ',')) '}' <#> char
-        , Array.zip labels types <#> \(Tuple l t) -> l <<+>> t
-        ] <#> vcat Boxes.left
-  pure (hsep 1 Boxes.left columns)
+  pure $ delimitedLiteral Vert '{' '}' (Array.zip labels types <#> \(Tuple l t) -> l <<+>> t)
+
+recordJsonCodec :: Array RecordProp -> Emit Box
+recordJsonCodec props = do
+  tell
+    [ "Data.Argonaut.Core as Argonaut"
+    , "Ccap.Codegen.Runtime as Runtime"
+    , "Foreign.Object as FO"
+    ]
+  writeProps <- recordWriteProps props
+  readProps <- recordReadProps props
+  let write = text "write: \\p -> Argonaut.fromObject $"
+                // indented
+                      (text "FO.fromFoldable"
+                        // indented writeProps)
+      names = props <#> \(RecordProp name _) -> text name
+      read = text "read: \\j -> do"
+              // indented
+                    (text "o <- Runtime.obj j"
+                      // readProps
+                      // (text "pure" <<+>> delimitedLiteral Horiz '{' '}' names))
+  pure $ delimitedLiteral Vert '{' '}' [ read, write ]
+
+recordWriteProps :: Array RecordProp -> Emit Box
+recordWriteProps props = do
+  types <- for props (\(RecordProp name t) -> do
+    x <- jsonCodec t
+    pure $ text "Tuple" <<+>> text (show name) <<+>> parens (x <<>> text ".write p." <<>> text name))
+  pure $ delimitedLiteral Vert '[' ']' types
+
+recordReadProps :: Array RecordProp -> Emit Box
+recordReadProps props = do
+  lines <- for props (\(RecordProp name t) -> do
+    x <- jsonCodec t
+    pure $ text name <<+>> text "<- Runtime.readProperty"
+              <<+>> text (show name) <<+>> x <<+>> text "o")
+  pure $ vcat Boxes.left lines

--- a/src/Ccap/Codegen/Runtime.purs
+++ b/src/Ccap/Codegen/Runtime.purs
@@ -1,0 +1,102 @@
+module Ccap.Codegen.Runtime where
+
+import Prelude
+
+import Data.Argonaut.Core (Json)
+import Data.Argonaut.Core as Argonaut
+import Data.Bifunctor (lmap)
+import Data.Decimal (Decimal)
+import Data.Decimal as Decimal
+import Data.Either (Either(..))
+import Data.Int as Int
+import Data.Maybe (Maybe(..), maybe)
+import Data.Newtype (class Newtype, unwrap, wrap)
+import Data.Traversable (traverse)
+import Foreign.Object (Object)
+import Foreign.Object (Object) as FO
+import Foreign.Object (lookup) as Object
+
+type Codec a b =
+  { read :: a -> Either String b
+  , write :: b -> a
+  }
+
+type JsonCodec a = Codec Json a
+
+jsonCodec_string :: JsonCodec String
+jsonCodec_string =
+  { read: maybe (Left "This value must be a string") Right <<< Argonaut.toString
+  , write: Argonaut.fromString
+  }
+
+jsonCodec_decimal :: JsonCodec Decimal
+jsonCodec_decimal = composeCodec
+  { read: maybe (Left "This value must be a decimal") Right <<< Decimal.fromString
+  , write: Decimal.toString
+  }
+  jsonCodec_string
+
+jsonCodec_number :: JsonCodec Number
+jsonCodec_number =
+  { read: maybe (Left "This value must be a number") Right <<< Argonaut.toNumber
+  , write: Argonaut.fromNumber
+  }
+
+jsonCodec_int :: JsonCodec Int
+jsonCodec_int = composeCodec
+  { read: maybe (Left "This value must be an integer") Right <<< Int.fromNumber
+  , write: Int.toNumber
+  }
+  jsonCodec_number
+
+jsonCodec_boolean :: JsonCodec Boolean
+jsonCodec_boolean =
+  { read: maybe (Left "This value must be a boolean") Right <<< Argonaut.toBoolean
+  , write: Argonaut.fromBoolean
+  }
+
+jsonCodec_maybe :: forall a. JsonCodec a -> JsonCodec (Maybe a)
+jsonCodec_maybe w =
+  { read: \j -> if Argonaut.isNull j then Right Nothing else map Just (w.read j)
+  , write: \a -> maybe Argonaut.jsonNull w.write a
+  }
+
+jsonCodec_array
+  :: forall a
+   . JsonCodec a
+  -> JsonCodec (Array a)
+jsonCodec_array inner =
+  { read: maybe (Left "This value must be an array") (traverse inner.read) <<< Argonaut.toArray
+  , write: Argonaut.fromArray <<< (map inner.write)
+  }
+
+readProperty :: forall a. String -> JsonCodec a -> FO.Object Json -> Either String a
+readProperty prop codec o = do
+  v <- maybe
+        (Left $ "Property " <> prop <> " does not exist")
+        Right
+        (Object.lookup prop o)
+  lmap (\s -> "Property " <> prop <> ": " <> s) (codec.read v)
+
+composeCodec
+  :: forall a b c
+   . Codec b c
+  -> Codec a b
+  -> Codec a c
+composeCodec codec1 codec2 =
+  { read: map (flip bind codec1.read) codec2.read
+  , write: codec1.write >>> codec2.write
+  }
+
+obj :: Json -> Either String (Object Json)
+obj = maybe (Left "This value must be an object") Right <<< Argonaut.toObject
+
+codec_newtype
+  :: forall t a b
+   . Newtype t b
+  => Codec a b
+  -> Codec a t
+codec_newtype = composeCodec
+  { read: Right <<< wrap
+  , write: unwrap
+  }

--- a/src/Ccap/Codegen/Shared.purs
+++ b/src/Ccap/Codegen/Shared.purs
@@ -1,9 +1,18 @@
 module Ccap.Codegen.Shared
-  ( OutputSpec
+  ( Emit
+  , Imports
+  , OutputSpec
+  , annotValue
+  , emit
   , indented
   ) where
 
-import Ccap.Codegen.Types (Module)
+import Prelude
+
+import Ccap.Codegen.Types (Annotation(..), AnnotationParam(..), Module)
+import Control.Monad.Writer (Writer, tell)
+import Data.Array as Array
+import Data.Maybe (Maybe)
 import Text.PrettyPrint.Boxes (Box, emptyBox, (<<>>))
 
 type OutputSpec =
@@ -16,3 +25,16 @@ indent = emptyBox 0 2
 
 indented :: Box -> Box
 indented = (<<>>) indent
+
+type Imports = Array String
+
+type Emit = Writer Imports
+
+emit :: forall a. Array String -> a -> Emit a
+emit imports a = map (const a) (tell imports)
+
+annotValue :: String -> String -> Array Annotation -> Maybe String
+annotValue annotKey paramKey annots = do
+  Annotation _ _ params <- Array.find (\(Annotation n _ _) -> n == annotKey) annots
+  AnnotationParam _ _ v <- Array.find (\(AnnotationParam n _ _) -> n == paramKey) params
+  v


### PR DESCRIPTION
(cherry-picked from e9525f4972d0083c324536edbcecd30228f8f160,
omiting the unrelated parts that were still in progress)
    
Conflicts:
            src/Ccap/Codegen/Scala.purs
