### PR TITLE
Rename built-in types to PureScript/Scala/Haskell style

### DIFF
--- a/samples/Case.tmpl
+++ b/samples/Case.tmpl
@@ -4,37 +4,37 @@ module Case {
     countyNo: Domains.CountyNoT
     caseType: Domains.CaseTypeT
     filingDate: Domains.DateT
-    isConfidential: boolean
-    isFiledWoCtofc: boolean
+    isConfidential: Boolean
+    isFiledWoCtofc: Boolean
     lastChargeSeqNo: Domains.ChargeSeqNoT
     lastCvJgSeqNo: Domains.CivilJdgmtSeqNoT
     lastHistSeqNo: Domains.HistSeqNoT
     lastPartySeqNo: Domains.PartyNoT
     lastRelSeqNo: Domains.RelSeqNoT
     statusCode: Domains.StatusCodeT
-    isSeal: boolean
-    isExpunge: boolean
-    isElectronicFiling: boolean
-    isPartySeal: boolean
-    bondId: optional Domains.BondIdT
-    branchId: optional Domains.BranchIdT
-    caption: optional Domains.CaptionT
-    daCaseNo: optional Domains.DaCaseNoT
-    dispCtofcNo: optional Domains.CtofcNoT
-    fileCtofcDate: optional Domains.DateT
-    filingCtofcNo: optional Domains.CtofcNoT
-    issAgencyNo: optional Domains.IssAgencyNoT
-    maintCode: optional Domains.MaintCodeT
-    oldCaseNo: optional string
-    plntfAgencyNo: optional Domains.PlntfAgencyNoT
-    previousRespCo: optional Domains.CtofcNoT
-    prosAgencyNo: optional Domains.ProsAgencyNoT
-    prosAtty: optional Domains.AttyNoT
-    respCtofcNo: optional Domains.CtofcNoT
-    wcisClsCode: optional Domains.WcisClsCodeT
-    unifiedCaseNo: optional Domains.UnifiedCaseNoT
-    statClsCode: optional Domains.WcisClsCodeT
-    optInCode: optional Domains.PublicOptInCodeT
+    isSeal: Boolean
+    isExpunge: Boolean
+    isElectronicFiling: Boolean
+    isPartySeal: Boolean
+    bondId: Maybe Domains.BondIdT
+    branchId: Maybe Domains.BranchIdT
+    caption: Maybe Domains.CaptionT
+    daCaseNo: Maybe Domains.DaCaseNoT
+    dispCtofcNo: Maybe Domains.CtofcNoT
+    fileCtofcDate: Maybe Domains.DateT
+    filingCtofcNo: Maybe Domains.CtofcNoT
+    issAgencyNo: Maybe Domains.IssAgencyNoT
+    maIntCode: Maybe Domains.MaIntCodeT
+    oldCaseNo: Maybe String
+    plntfAgencyNo: Maybe Domains.PlntfAgencyNoT
+    previousRespCo: Maybe Domains.CtofcNoT
+    prosAgencyNo: Maybe Domains.ProsAgencyNoT
+    prosAtty: Maybe Domains.AttyNoT
+    respCtofcNo: Maybe Domains.CtofcNoT
+    wcisClsCode: Maybe Domains.WcisClsCodeT
+    unifiedCaseNo: Maybe Domains.UnifiedCaseNoT
+    statClsCode: Maybe Domains.WcisClsCodeT
+    optInCode: Maybe Domains.PublicOptInCodeT
     lastDocNumber: Domains.CaseDocNoT
   }
 }

--- a/samples/County.tmpl
+++ b/samples/County.tmpl
@@ -5,58 +5,58 @@
 // - A template file consists of one or more modules.
 // - A module consists of one or more type declarations.
 // - Non-primitive type and module names are camel-case with an initial upper-case letter.
-// - Any type can be marked as optional (Maybe in PureScript, Option in Scala)
+// - Any type can be marked as Maybe (Maybe in PureScript, Option in Scala)
 // - Any type can be tagged with wrap (newtype in PureScript, Scalaz @@ in Scala)
 //
 // The following primitive types are supported:
-//   - boolean
-//   - int
-//   - decimal
-//   - string
+//   - Boolean
+//   - Int
+//   - Decimal
+//   - String
 //
 // Record types:
 //   - Contain one one or more properties.
 //   - Property names are camel-case with an initial lower-case letter.
 //   - Record types must be given a name to be nested within a record or used
-//     in an array type.
+//     in an Array type.
 //
 
 module County /* <scala package="gov.wicourts.codegen"> <purs modulePrefix="Ccap.Codegen"> */ {
   type CountyNo: Domains.CountyNoT
-  type CountyName: string <validations maxLength="32">
-  type OtherCountyName: wrap string <validations maxLength="32">
-  type AssessFacilityId: wrap int
-  type SomethingMoney: wrap decimal
+  type CountyName: String <validations maxLength="32">
+  type OtherCountyName: wrap String <validations maxLength="32">
+  type AssessFacilityId: wrap Int
+  type SomethingMoney: wrap Decimal
 
   type County: {
     countyNo: Domains.CountyNoT
     countyNoX: CountyNo
     countyName: CountyName
-    assessFacilityId: optional AssessFacilityId
-    soapPort: int
+    assessFacilityId: Maybe AssessFacilityId
+    soapPort: Int
   }
 
   type Big: {
-    a1: int
-    b1: string
-    c1: decimal
-    d1: boolean
-    a2: int
-    b2: string
-    c2: decimal
-    d2: boolean
-    a3: int
-    b3: string
-    c3: decimal
-    d3: boolean
-    a4: int
-    b4: string
-    c4: decimal
-    d4: boolean
+    a1: Int
+    b1: String
+    c1: Decimal
+    d1: Boolean
+    a2: Int
+    b2: String
+    c2: Decimal
+    d2: Boolean
+    a3: Int
+    b3: String
+    c3: Decimal
+    d3: Boolean
+    a4: Int
+    b4: String
+    c4: Decimal
+    d4: Boolean
   }
 
   type Response: {
-    counties: array County
+    counties: Array County
   }
 
   type CountyEnum: [
@@ -67,7 +67,7 @@ module County /* <scala package="gov.wicourts.codegen"> <purs modulePrefix="Ccap
   ]
 
   // A date, encoded per RFC 3339.
-  type Date: wrap string
+  type Date: wrap String
     <validations maxLength="32">
     <scala
       t="org.joda.time.LocalDate"

--- a/samples/DateTimeSupport.tmpl
+++ b/samples/DateTimeSupport.tmpl
@@ -1,13 +1,13 @@
 module DateTimeSupport {
-  type Date: wrap string
+  type Date: wrap String
     <scala
       t="org.joda.time.LocalDate"
       decode="Decoder.date"
-      encode="gov.wicourts.common.LocalDateOps.sortableDateFormat.print">
+      encode="gov.wicourts.common.LocalDateOps.sortableDateFormat.prInt">
     <purs
       t="Ccap.Common.DateTime.Date.Date"
       decode="Ccap.Common.DateTime.Date.decodeIsoMadison"
       encode="Ccap.Common.DateTime.Date.inIso8601ExtendedDateFormat">
-  type Time: wrap string
-  type Timestamp: wrap string
+  type Time: wrap String
+  type Timestamp: wrap String
 }

--- a/samples/Domains.tmpl
+++ b/samples/Domains.tmpl
@@ -1,1237 +1,1237 @@
 module Domains {
-  type ABACityStateT: wrap decimal
-  type ABARoutingNoT: wrap string
+  type ABACityStateT: wrap Decimal
+  type ABARoutingNoT: wrap String
     <validations maxLength="9">
-  type AccDocNoT: wrap int
-  type AccSeverityT: wrap string
+  type AccDocNoT: wrap Int
+  type AccSeverityT: wrap String
     <validations maxLength="1">
-  type AccidentDocNoT: wrap string
+  type AccidentDocNoT: wrap String
     <validations maxLength="10">
-  type AcctCatCodeT: wrap string
+  type AcctCatCodeT: wrap String
     <validations maxLength="1">
-  type AcctCodeT: wrap string
+  type AcctCodeT: wrap String
     <validations maxLength="5">
-  type AcctNoT: wrap string
+  type AcctNoT: wrap String
     <validations maxLength="15">
-  type AcctTypeT: wrap string
+  type AcctTypeT: wrap String
     <validations maxLength="3">
-  type ActionCodeT: wrap string
+  type ActionCodeT: wrap String
     <validations maxLength="5">
-  type ActionDescrT: wrap string
+  type ActionDescrT: wrap String
     <validations maxLength="50">
-  type ActionPayTypeT: wrap string
+  type ActionPayTypeT: wrap String
     <validations maxLength="1">
-  type ActionSeqNoT: wrap int
-  type ActionTypeT: wrap string
+  type ActionSeqNoT: wrap Int
+  type ActionTypeT: wrap String
     <validations maxLength="1">
-  type ActivStatusCodeT: wrap string
+  type ActivStatusCodeT: wrap String
     <validations maxLength="4">
-  type ActivStatusDescrT: wrap string
+  type ActivStatusDescrT: wrap String
     <validations maxLength="20">
-  type ActiveDirectGuidT: wrap string
+  type ActiveDirectGuidT: wrap String
     <validations maxLength="36">
-  type ActivityDescrT: wrap string
+  type ActivityDescrT: wrap String
     <validations maxLength="100">
-  type ActivityTypeT: wrap string
+  type ActivityTypeT: wrap String
     <validations maxLength="5">
-  type ActorNameT: wrap string
+  type ActorNameT: wrap String
     <validations maxLength="30">
-  type AddrSeqNoT: wrap int
-  type AddressIDT: wrap int
-  type AddtlReasonDescT: wrap string
+  type AddrSeqNoT: wrap Int
+  type AddressIDT: wrap Int
+  type AddtlReasonDescT: wrap String
     <validations maxLength="50">
-  type AddtlReasonIDT: wrap int
-  type AgencyTypeT: wrap string
+  type AddtlReasonIDT: wrap Int
+  type AgencyTypeT: wrap String
     <validations maxLength="1">
-  type AliasCodeT: wrap string
+  type AliasCodeT: wrap String
     <validations maxLength="3">
-  type AliasNoT: wrap int
-  type AmendNoNewT: wrap int
-  type AnnotRangePageNoT: wrap int
-  type AnnotRngPgStOffsT: wrap int
-  type AnnotTransSeqNoT: wrap int
-  type AnnotationQuoteT: wrap string
-  type AnnotationRangeEndOffsetT: wrap int
-  type AnnotationRangeEndT: wrap string
-  type AnnotationRangeStartOffsetT: wrap int
-  type AnnotationRangeStartT: wrap string
-  type AnnotationSeqNoT: wrap int
-  type AnnotationTextT: wrap string
-  type AppNameT: wrap string
+  type AliasNoT: wrap Int
+  type AmendNoNewT: wrap Int
+  type AnnotRangePageNoT: wrap Int
+  type AnnotRngPgStOffsT: wrap Int
+  type AnnotTransSeqNoT: wrap Int
+  type AnnotationQuoteT: wrap String
+  type AnnotationRangeEndOffsetT: wrap Int
+  type AnnotationRangeEndT: wrap String
+  type AnnotationRangeStartOffsetT: wrap Int
+  type AnnotationRangeStartT: wrap String
+  type AnnotationSeqNoT: wrap Int
+  type AnnotationTextT: wrap String
+  type AppNameT: wrap String
     <validations maxLength="20">
-  type AppearCodeDescrT: wrap string
+  type AppearCodeDescrT: wrap String
     <validations maxLength="15">
-  type AppearCodeT: wrap string
+  type AppearCodeT: wrap String
     <validations maxLength="1">
-  type AppearCourtNoT: wrap int
-  type AppearancesT: wrap string
+  type AppearCourtNoT: wrap Int
+  type AppearancesT: wrap String
     <validations maxLength="140">
-  type ApplicationCodeT: wrap string
+  type ApplicationCodeT: wrap String
     <validations maxLength="5">
-  type ArrestCaseNoT: wrap string
+  type ArrestCaseNoT: wrap String
     <validations maxLength="12">
-  type ArrestTrackingNoT: wrap string
+  type ArrestTrackingNoT: wrap String
     <validations maxLength="14">
-  type AschPctBasisT: wrap string
+  type AschPctBasisT: wrap String
     <validations maxLength="5">
-  type AsgnOptionIDT: wrap int
-  type AssessFacilityIdT: wrap string
+  type AsgnOptionIDT: wrap Int
+  type AssessFacilityIdT: wrap String
     <validations maxLength="10">
-  type AssessModCodeT: wrap string
+  type AssessModCodeT: wrap String
     <validations maxLength="3">
-  type AssignmentMethodT: wrap string
+  type AssignmentMethodT: wrap String
     <validations maxLength="1">
-  type AssignmentNoT: wrap string
+  type AssignmentNoT: wrap String
     <validations maxLength="9">
-  type AssignmentTypeT: wrap string
+  type AssignmentTypeT: wrap String
     <validations maxLength="2">
-  type AttachmentSeqNoT: wrap int
-  type AttnT: wrap string
+  type AttachmentSeqNoT: wrap Int
+  type AttnT: wrap String
     <validations maxLength="100">
-  type AttyAddrLocSeqNoT: wrap int
-  type AttyAddrNoT: wrap int
-  type AttyAdmitByCodeT: wrap string
+  type AttyAddrLocSeqNoT: wrap Int
+  type AttyAddrNoT: wrap Int
+  type AttyAdmitByCodeT: wrap String
     <validations maxLength="1">
-  type AttyAdmitByDescrT: wrap string
+  type AttyAdmitByDescrT: wrap String
     <validations maxLength="20">
-  type AttyAdmitCodeT: wrap string
+  type AttyAdmitCodeT: wrap String
     <validations maxLength="4">
-  type AttyAdmitDescrT: wrap string
+  type AttyAdmitDescrT: wrap String
     <validations maxLength="20">
-  type AttyEventCodeT: wrap string
+  type AttyEventCodeT: wrap String
     <validations maxLength="3">
-  type AttyEventDescrT: wrap string
+  type AttyEventDescrT: wrap String
     <validations maxLength="50">
-  type AttyFirmIdT: wrap string
+  type AttyFirmIdT: wrap String
     <validations maxLength="7">
-  type AttyFirmNameT: wrap string
+  type AttyFirmNameT: wrap String
     <validations maxLength="100">
-  type AttyNoT: wrap int
-  type AttySeqNoT: wrap int
-  type AttyStatusCodeT: wrap string
+  type AttyNoT: wrap Int
+  type AttySeqNoT: wrap Int
+  type AttyStatusCodeT: wrap String
     <validations maxLength="1">
-  type AttyStatusDescrT: wrap string
+  type AttyStatusDescrT: wrap String
     <validations maxLength="20">
-  type AttyTitleCodeT: wrap string
+  type AttyTitleCodeT: wrap String
     <validations maxLength="2">
-  type AttyTitleDescrT: wrap string
+  type AttyTitleDescrT: wrap String
     <validations maxLength="100">
-  type AuditIDT: wrap int
-  type AuthorityTypeT: wrap string
+  type AuditIDT: wrap Int
+  type AuthorityTypeT: wrap String
     <validations maxLength="24">
-  type AvailDateRangeT: wrap string
+  type AvailDateRangeT: wrap String
     <validations maxLength="50">
-  type BailiffNoT: wrap string
+  type BailiffNoT: wrap String
     <validations maxLength="5">
-  type BankAcctNoT: wrap string
+  type BankAcctNoT: wrap String
     <validations maxLength="15">
-  type BankNoT: wrap string
+  type BankNoT: wrap String
     <validations maxLength="9">
-  type BarEffStatusT: wrap string
+  type BarEffStatusT: wrap String
     <validations maxLength="60">
-  type BarSchoolCodeT: wrap string
+  type BarSchoolCodeT: wrap String
     <validations maxLength="4">
-  type BarServiceClassT: wrap string
+  type BarServiceClassT: wrap String
     <validations maxLength="6">
-  type BasePathT: wrap string
+  type BasePathT: wrap String
     <validations maxLength="100">
-  type BatchIdT: wrap string
+  type BatchIdT: wrap String
     <validations maxLength="36">
-  type BatchNoT: wrap int
-  type BillerGroupIdT: wrap string
+  type BatchNoT: wrap Int
+  type BillerGroupIdT: wrap String
     <validations maxLength="3">
-  type BillerIdT: wrap string
+  type BillerIdT: wrap String
     <validations maxLength="3">
-  type BondCondSeqNoT: wrap int
-  type BondCondTemplCodeT: wrap string
+  type BondCondSeqNoT: wrap Int
+  type BondCondTemplCodeT: wrap String
     <validations maxLength="5">
-  type BondCondTemplDescT: wrap string
+  type BondCondTemplDescT: wrap String
     <validations maxLength="30">
-  type BondCondTextT: wrap string
+  type BondCondTextT: wrap String
     <validations maxLength="200">
-  type BondCondTypeDescrT: wrap string
+  type BondCondTypeDescrT: wrap String
     <validations maxLength="15">
-  type BondCondTypeT: wrap string
+  type BondCondTypeT: wrap String
     <validations maxLength="5">
-  type BondConditionsT: wrap string
-  type BondIdT: wrap string
+  type BondConditionsT: wrap String
+  type BondIdT: wrap String
     <validations maxLength="15">
-  type BondSeqNoT: wrap int
-  type BondType2T: wrap string
+  type BondSeqNoT: wrap Int
+  type BondType2T: wrap String
     <validations maxLength="1">
-  type BondTypeT: wrap string
+  type BondTypeT: wrap String
     <validations maxLength="2">
-  type BookCaseNoT: wrap string
+  type BookCaseNoT: wrap String
     <validations maxLength="12">
-  type BookingORIT: wrap string
+  type BookingORIT: wrap String
     <validations maxLength="9">
-  type BooleanT: wrap boolean
-  type BranchIdT: wrap string
+  type BooleanT: wrap Boolean
+  type BranchIdT: wrap String
     <validations maxLength="2">
-  type BranchNewT: wrap int
-  type BusinessNameT: wrap string
+  type BranchNewT: wrap Int
+  type BusinessNameT: wrap String
     <validations maxLength="60">
-  type CCExpT: wrap string
+  type CCExpT: wrap String
     <validations maxLength="7">
-  type CPIMnemonicT: wrap string
+  type CPIMnemonicT: wrap String
     <validations maxLength="10">
-  type CalAccountIdT: wrap string
+  type CalAccountIdT: wrap String
     <validations maxLength="40">
-  type CalDispoCodeT: wrap string
+  type CalDispoCodeT: wrap String
     <validations maxLength="1">
-  type CalDurationT: wrap decimal
-  type CalExportOptionT: wrap string
+  type CalDurationT: wrap Decimal
+  type CalExportOptionT: wrap String
     <validations maxLength="1">
-  type CalMessageIdT: wrap string
+  type CalMessageIdT: wrap String
     <validations maxLength="100">
-  type CalSeqNoT: wrap int
-  type CalSmsMessageNoT: wrap int
-  type CapPrefixDescrT: wrap string
+  type CalSeqNoT: wrap Int
+  type CalSmsMessageNoT: wrap Int
+  type CapPrefixDescrT: wrap String
     <validations maxLength="150">
-  type CapPrefixSeqNoT: wrap int
-  type CaptionT: wrap string
+  type CapPrefixSeqNoT: wrap Int
+  type CaptionT: wrap String
     <validations maxLength="140">
-  type CaseCloseSummaryT: wrap string
-  type CaseDocNoT: wrap int
-  type CaseNoT: wrap string
+  type CaseCloseSummaryT: wrap String
+  type CaseDocNoT: wrap Int
+  type CaseNoT: wrap String
     <validations maxLength="14">
-  type CaseNoteSeqNoT: wrap int
-  type CaseNoteT: wrap string
-  type CaseOptInSeqNoT: wrap int
-  type CaseSeqNoNewT: wrap int
-  type CaseSeqNoT: wrap int
-  type CaseSuffixCodeT: wrap string
+  type CaseNoteSeqNoT: wrap Int
+  type CaseNoteT: wrap String
+  type CaseOptInSeqNoT: wrap Int
+  type CaseSeqNoNewT: wrap Int
+  type CaseSeqNoT: wrap Int
+  type CaseSuffixCodeT: wrap String
     <validations maxLength="5">
-  type CaseSuffixDescrT: wrap string
+  type CaseSuffixDescrT: wrap String
     <validations maxLength="40">
-  type CaseTransitionCdeT: wrap string
+  type CaseTransitionCdeT: wrap String
     <validations maxLength="20">
-  type CaseTypeAbbrT: wrap string
+  type CaseTypeAbbrT: wrap String
     <validations maxLength="2">
-  type CaseTypeDescT: wrap string
+  type CaseTypeDescT: wrap String
     <validations maxLength="50">
-  type CaseTypeT: wrap string
+  type CaseTypeT: wrap String
     <validations maxLength="2">
-  type CashierCodeT: wrap string
+  type CashierCodeT: wrap String
     <validations maxLength="3">
-  type ChallengeSeqNoT: wrap int
-  type ChargeIdT: wrap string
+  type ChallengeSeqNoT: wrap Int
+  type ChargeIdT: wrap String
     <validations maxLength="15">
-  type ChargeNoT: wrap int
-  type ChargeSeqNoT: wrap int
-  type ChargeStatusCodeT: wrap string
+  type ChargeNoT: wrap Int
+  type ChargeSeqNoT: wrap Int
+  type ChargeStatusCodeT: wrap String
     <validations maxLength="2">
-  type ChargeToStepSeqNoT: wrap int
-  type CheckHeightT: wrap decimal
-  type CheckNameT: wrap string
+  type ChargeToStepSeqNoT: wrap Int
+  type CheckHeightT: wrap Decimal
+  type CheckNameT: wrap String
     <validations maxLength="60">
-  type CheckNoT: wrap string
+  type CheckNoT: wrap String
     <validations maxLength="25">
-  type ChgDispoCodeDescrT: wrap string
+  type ChgDispoCodeDescrT: wrap String
     <validations maxLength="50">
-  type ChildWelEpisodeIdT: wrap int
-  type ChildWelHistSeqNoT: wrap int
-  type ChildWelfareIdNoT: wrap int
-  type CitnFilingSeqNoT: wrap int
-  type CitnNoT: wrap string
+  type ChildWelEpisodeIdT: wrap Int
+  type ChildWelHistSeqNoT: wrap Int
+  type ChildWelfareIdNoT: wrap Int
+  type CitnFilingSeqNoT: wrap Int
+  type CitnNoT: wrap String
     <validations maxLength="16">
-  type CityT: wrap string
+  type CityT: wrap String
     <validations maxLength="50">
-  type CityTypeT: wrap string
+  type CityTypeT: wrap String
     <validations maxLength="1">
-  type CivilEventTypeT: wrap string
+  type CivilEventTypeT: wrap String
     <validations maxLength="2">
-  type CivilJdgmtSeqNoT: wrap int
-  type CivilMoneyCodeT: wrap string
+  type CivilJdgmtSeqNoT: wrap Int
+  type CivilMoneyCodeT: wrap String
     <validations maxLength="5">
-  type ClassNameT: wrap string
+  type ClassNameT: wrap String
     <validations maxLength="255">
-  type ClientMessageIdT: wrap string
+  type ClientMessageIdT: wrap String
     <validations maxLength="50">
-  type CollAgencyCodeT: wrap string
+  type CollAgencyCodeT: wrap String
     <validations maxLength="3">
-  type CollHistCodeT: wrap string
+  type CollHistCodeT: wrap String
     <validations maxLength="5">
-  type ColumnNameT: wrap string
+  type ColumnNameT: wrap String
     <validations maxLength="30">
-  type ColumnOrderNoT: wrap int
-  type CommentT: wrap string
+  type ColumnOrderNoT: wrap Int
+  type CommentT: wrap String
     <validations maxLength="45">
-  type ConcurConsecCodeT: wrap string
+  type ConcurConsecCodeT: wrap String
     <validations maxLength="1">
-  type ConcurConsecDtlNoT: wrap int
-  type ConcurConsecSeqNoT: wrap int
-  type CondCodeT: wrap string
+  type ConcurConsecDtlNoT: wrap Int
+  type ConcurConsecSeqNoT: wrap Int
+  type CondCodeT: wrap String
     <validations maxLength="4">
-  type CondSeqNoT: wrap int
-  type ConditionTypeT: wrap string
+  type CondSeqNoT: wrap Int
+  type ConditionTypeT: wrap String
     <validations maxLength="1">
-  type ConfirmationIdT: wrap string
+  type ConfirmationIdT: wrap String
     <validations maxLength="36">
-  type ConstraintNameT: wrap string
+  type ConstraintNameT: wrap String
     <validations maxLength="50">
-  type ConstraintSeqNoT: wrap int
-  type CorrelationIDT: wrap decimal
-  type CorrelationTypeT: wrap string
+  type ConstraintSeqNoT: wrap Int
+  type CorrelationIDT: wrap Decimal
+  type CorrelationTypeT: wrap String
     <validations maxLength="20">
-  type CostAgainstCodeT: wrap string
+  type CostAgainstCodeT: wrap String
     <validations maxLength="1">
-  type CostAgainstDescrT: wrap string
+  type CostAgainstDescrT: wrap String
     <validations maxLength="10">
-  type CountryIDT: wrap int
-  type CountryT: wrap string
+  type CountryIDT: wrap Int
+  type CountryT: wrap String
     <validations maxLength="50">
-  type CountyNameT: wrap string
+  type CountyNameT: wrap String
     <validations maxLength="20">
-  type CountyNoT: wrap int
-  type CourtActionCodeT: wrap string
+  type CountyNoT: wrap Int
+  type CourtActionCodeT: wrap String
     <validations maxLength="1">
-  type CourtActionDescrT: wrap string
+  type CourtActionDescrT: wrap String
     <validations maxLength="20">
-  type CourtDebitAcctNoT: wrap int
-  type CourtDebitActNameT: wrap string
+  type CourtDebitAcctNoT: wrap Int
+  type CourtDebitActNameT: wrap String
     <validations maxLength="50">
-  type CourtRptrCodeT: wrap string
+  type CourtRptrCodeT: wrap String
     <validations maxLength="4">
-  type CourtTypeCodeT: wrap string
+  type CourtTypeCodeT: wrap String
     <validations maxLength="2">
-  type CourtTypeDescrT: wrap string
+  type CourtTypeDescrT: wrap String
     <validations maxLength="40">
-  type CpiT: wrap int
-  type CtofcCaseSeqNoT: wrap int
-  type CtofcNoT: wrap string
+  type CpiT: wrap Int
+  type CtofcCaseSeqNoT: wrap Int
+  type CtofcNoT: wrap String
     <validations maxLength="4">
-  type CtofcNoteSeqNoT: wrap int
-  type CtofcNoteT: wrap string
-  type CtofcNotificSeqNoT: wrap int
-  type CtofcTypeCodeT: wrap string
+  type CtofcNoteSeqNoT: wrap Int
+  type CtofcNoteT: wrap String
+  type CtofcNotificSeqNoT: wrap Int
+  type CtofcTypeCodeT: wrap String
     <validations maxLength="1">
-  type CustomSearchNameT: wrap string
+  type CustomSearchNameT: wrap String
     <validations maxLength="60">
-  type CustomSearchSeqNoT: wrap int
-  type CustomViewNameT: wrap string
+  type CustomSearchSeqNoT: wrap Int
+  type CustomViewNameT: wrap String
     <validations maxLength="60">
-  type CustomViewSeqNoT: wrap int
-  type CvJEventSeqNoT: wrap int
-  type CvJMoneySeqNoT: wrap int
-  type CycleCodeT: wrap string
+  type CustomViewSeqNoT: wrap Int
+  type CvJEventSeqNoT: wrap Int
+  type CvJMoneySeqNoT: wrap Int
+  type CycleCodeT: wrap String
     <validations maxLength="2">
-  type DMVSeqNoT: wrap int
-  type DNRCustomerNoT: wrap int
-  type DNREnvelopeNoT: wrap int
-  type DNRFormVersCodeT: wrap string
+  type DMVSeqNoT: wrap Int
+  type DNRCustomerNoT: wrap Int
+  type DNREnvelopeNoT: wrap Int
+  type DNRFormVersCodeT: wrap String
     <validations maxLength="10">
-  type DNRLicenseCodeT: wrap string
+  type DNRLicenseCodeT: wrap String
     <validations maxLength="3">
-  type DNRLicenseDescrT: wrap string
+  type DNRLicenseDescrT: wrap String
     <validations maxLength="100">
-  type DNRLocTypeDescrT: wrap string
+  type DNRLocTypeDescrT: wrap String
     <validations maxLength="40">
-  type DNRLocationCodeT: wrap int
-  type DNRLocationDescrT: wrap string
+  type DNRLocationCodeT: wrap Int
+  type DNRLocationDescrT: wrap String
     <validations maxLength="50">
-  type DNRLocationTypeT: wrap string
+  type DNRLocationTypeT: wrap String
     <validations maxLength="1">
-  type DNRMoneyCodeT: wrap string
+  type DNRMoneyCodeT: wrap String
     <validations maxLength="5">
-  type DNRRegionCodeT: wrap string
+  type DNRRegionCodeT: wrap String
     <validations maxLength="2">
-  type DNRRegionDescrT: wrap string
+  type DNRRegionDescrT: wrap String
     <validations maxLength="30">
-  type DNRSentSeqNoT: wrap int
-  type DNRSeqNoT: wrap int
-  type DOCSeqNoT: wrap int
-  type DOJSeqNoT: wrap int
-  type DOTSeqNoT: wrap int
-  type DTDIdT: wrap int
-  type DTDT: wrap string
+  type DNRSentSeqNoT: wrap Int
+  type DNRSeqNoT: wrap Int
+  type DOCSeqNoT: wrap Int
+  type DOJSeqNoT: wrap Int
+  type DOTSeqNoT: wrap Int
+  type DTDIdT: wrap Int
+  type DTDT: wrap String
     <validations maxLength="255">
-  type DWDWarrantNoT: wrap string
+  type DWDWarrantNoT: wrap String
     <validations maxLength="15">
-  type DaCaseNoT: wrap string
+  type DaCaseNoT: wrap String
     <validations maxLength="12">
   type DateT: wrap DateTimeSupport.Date
-  type DaysServedT: wrap decimal
-  type DbIdT: wrap string
+  type DaysServedT: wrap Decimal
+  type DbIdT: wrap String
     <validations maxLength="20">
-  type DebtHistSeqNoT: wrap int
-  type DebtNoT: wrap string
+  type DebtHistSeqNoT: wrap Int
+  type DebtNoT: wrap String
     <validations maxLength="5">
-  type DebtSeqNoT: wrap int
-  type DebtStatusCodeT: wrap string
+  type DebtSeqNoT: wrap Int
+  type DebtStatusCodeT: wrap String
     <validations maxLength="5">
-  type DebtStatusDescrT: wrap string
+  type DebtStatusDescrT: wrap String
     <validations maxLength="30">
-  type DebtStatusHistCdT: wrap string
+  type DebtStatusHistCdT: wrap String
     <validations maxLength="5">
-  type DefReqdReplyT: wrap string
+  type DefReqdReplyT: wrap String
     <validations maxLength="1">
-  type DefendantIdT: wrap string
+  type DefendantIdT: wrap String
     <validations maxLength="15">
-  type DemeritPointT: wrap int
-  type DescriptionT: wrap string
+  type DemeritPointT: wrap Int
+  type DescriptionT: wrap String
     <validations maxLength="100">
-  type DisbAgencyNameT: wrap string
+  type DisbAgencyNameT: wrap String
     <validations maxLength="50">
-  type DisbAgencyNoT: wrap string
+  type DisbAgencyNoT: wrap String
     <validations maxLength="4">
-  type DisbBatchNoT: wrap int
-  type DischargeReasonT: wrap int
-  type DischrgReasDescrT: wrap string
+  type DisbBatchNoT: wrap Int
+  type DischargeReasonT: wrap Int
+  type DischrgReasDescrT: wrap String
     <validations maxLength="40">
-  type DispoCodeDescrT: wrap string
+  type DispoCodeDescrT: wrap String
     <validations maxLength="40">
-  type DispoCodeT: wrap string
+  type DispoCodeT: wrap String
     <validations maxLength="5">
-  type DistinguishedNameT: wrap string
+  type DistinguishedNameT: wrap String
     <validations maxLength="160">
-  type DistrictNoT: wrap int
-  type DivisionCodeT: wrap string
+  type DistrictNoT: wrap Int
+  type DivisionCodeT: wrap String
     <validations maxLength="24">
-  type DktTxtT: wrap string
+  type DktTxtT: wrap String
     <validations maxLength="10000">
-  type DmvCommunityCodeT: wrap int
-  type DmvCommunityNameT: wrap string
+  type DmvCommunityCodeT: wrap Int
+  type DmvCommunityNameT: wrap String
     <validations maxLength="35">
-  type DocAccessCodeT: wrap string
+  type DocAccessCodeT: wrap String
     <validations maxLength="50">
-  type DocCategoryDescrT: wrap string
+  type DocCategoryDescrT: wrap String
     <validations maxLength="50">
-  type DocCategoryT: wrap string
+  type DocCategoryT: wrap String
     <validations maxLength="5">
-  type DocDOCTypeT: wrap string
+  type DocDOCTypeT: wrap String
     <validations maxLength="10">
-  type DocDraftIdT: wrap int
-  type DocGroupNameT: wrap string
+  type DocDraftIdT: wrap Int
+  type DocGroupNameT: wrap String
     <validations maxLength="25">
-  type DocGroupSeqNoT: wrap int
-  type DocIdT: wrap int
-  type DocIndexSeqNoT: wrap int
-  type DocIndexStatusT: wrap string
+  type DocGroupSeqNoT: wrap Int
+  type DocIdT: wrap Int
+  type DocIndexSeqNoT: wrap Int
+  type DocIndexStatusT: wrap String
     <validations maxLength="1">
-  type DocNameT: wrap string
+  type DocNameT: wrap String
     <validations maxLength="50">
-  type DocNotcHistSeqNoT: wrap int
-  type DocNoteT: wrap string
-  type DocNoteTransSeqNoT: wrap int
-  type DocTextT: wrap string
+  type DocNotcHistSeqNoT: wrap Int
+  type DocNoteT: wrap String
+  type DocNoteTransSeqNoT: wrap Int
+  type DocTextT: wrap String
     <validations maxLength="10000000">
-  type DocTypeDescrT: wrap string
+  type DocTypeDescrT: wrap String
     <validations maxLength="50">
-  type DocTypeT: wrap string
+  type DocTypeT: wrap String
     <validations maxLength="5">
-  type DocViewSeqNoT: wrap int
-  type DocletNameT: wrap string
+  type DocViewSeqNoT: wrap Int
+  type DocletNameT: wrap String
     <validations maxLength="15">
-  type DocletTabSeqNoT: wrap int
-  type DocumentTextT: wrap string
-  type DomainNameT: wrap string
+  type DocletTabSeqNoT: wrap Int
+  type DocumentTextT: wrap String
+  type DomainNameT: wrap String
     <validations maxLength="255">
-  type DorCountyNoT: wrap int
-  type DotCodeT: wrap int
-  type DrawerIdT: wrap int
-  type DriverLicNoT: wrap string
+  type DorCountyNoT: wrap Int
+  type DotCodeT: wrap Int
+  type DrawerIdT: wrap Int
+  type DriverLicNoT: wrap String
     <validations maxLength="20">
-  type EAccountNoT: wrap int
-  type EAccountStatusT: wrap string
+  type EAccountNoT: wrap Int
+  type EAccountStatusT: wrap String
     <validations maxLength="1">
-  type EAcctCCEmailSeqNoT: wrap int
-  type EFileBatchIdT: wrap int
-  type EPayTranSeqNoT: wrap int
-  type EPmtCitnStatusT: wrap string
+  type EAcctCCEmailSeqNoT: wrap Int
+  type EFileBatchIdT: wrap Int
+  type EPayTranSeqNoT: wrap Int
+  type EPmtCitnStatusT: wrap String
     <validations maxLength="1">
-  type EPmtRcvblStatusT: wrap string
+  type EPmtRcvblStatusT: wrap String
     <validations maxLength="1">
-  type ESBRoutingCodeT: wrap string
+  type ESBRoutingCodeT: wrap String
     <validations maxLength="3">
-  type EcourtsAcctLongDescrT: wrap string
+  type EcourtsAcctLongDescrT: wrap String
     <validations maxLength="1000">
-  type EcourtsAcctShortDescrT: wrap string
+  type EcourtsAcctShortDescrT: wrap String
     <validations maxLength="50">
-  type EcourtsAcctTypeSeqNoT: wrap int
-  type EcourtsAddrSeqNoT: wrap int
-  type EcourtsAuthorityTypeT: wrap string
+  type EcourtsAcctTypeSeqNoT: wrap Int
+  type EcourtsAddrSeqNoT: wrap Int
+  type EcourtsAuthorityTypeT: wrap String
     <validations maxLength="255">
-  type EcourtsCompanyNameT: wrap string
+  type EcourtsCompanyNameT: wrap String
     <validations maxLength="100">
-  type EcourtsCompanySeqNoT: wrap int
-  type EcourtsFirmNameT: wrap string
+  type EcourtsCompanySeqNoT: wrap Int
+  type EcourtsFirmNameT: wrap String
     <validations maxLength="100">
-  type EcourtsFirmSeqNoT: wrap int
-  type EcourtsGroupSeqNoT: wrap int
-  type EcourtsLockCodeT: wrap string
+  type EcourtsFirmSeqNoT: wrap Int
+  type EcourtsGroupSeqNoT: wrap Int
+  type EcourtsLockCodeT: wrap String
     <validations maxLength="2">
-  type EcourtsPasswordT: wrap string
+  type EcourtsPasswordT: wrap String
     <validations maxLength="60">
-  type EcourtsTargetT: wrap string
+  type EcourtsTargetT: wrap String
     <validations maxLength="60">
-  type EcourtsUserIdT: wrap string
+  type EcourtsUserIdT: wrap String
     <validations maxLength="32">
-  type EcourtsYubiKeyIdT: wrap string
+  type EcourtsYubiKeyIdT: wrap String
     <validations maxLength="40">
-  type EmailT: wrap string
+  type EmailT: wrap String
     <validations maxLength="255">
-  type EmployerT: wrap string
+  type EmployerT: wrap String
     <validations maxLength="100">
-  type EnfmtActionCodeT: wrap string
+  type EnfmtActionCodeT: wrap String
     <validations maxLength="2">
-  type EnfmtDescrT: wrap string
+  type EnfmtDescrT: wrap String
     <validations maxLength="25">
-  type EventCatDescrT: wrap string
+  type EventCatDescrT: wrap String
     <validations maxLength="20">
-  type EventCategoryT: wrap string
+  type EventCategoryT: wrap String
     <validations maxLength="3">
-  type EventCodeT: wrap string
+  type EventCodeT: wrap String
     <validations maxLength="3">
-  type EventDescrT: wrap string
+  type EventDescrT: wrap String
     <validations maxLength="50">
-  type EventStatusCodeT: wrap string
+  type EventStatusCodeT: wrap String
     <validations maxLength="4">
-  type EventStatusDescrT: wrap string
+  type EventStatusDescrT: wrap String
     <validations maxLength="20">
-  type EventTypeCodeDescT: wrap string
+  type EventTypeCodeDescT: wrap String
     <validations maxLength="20">
-  type EventTypeCodeT: wrap string
+  type EventTypeCodeT: wrap String
     <validations maxLength="1">
-  type EventTypeT: wrap string
+  type EventTypeT: wrap String
     <validations maxLength="5">
-  type ExLogSeqNoT: wrap int
-  type ExpRecTypeT: wrap string
+  type ExLogSeqNoT: wrap Int
+  type ExpRecTypeT: wrap String
     <validations maxLength="1">
-  type ExpenseSeqNoT: wrap int
-  type ExpenseTypeT: wrap string
+  type ExpenseSeqNoT: wrap Int
+  type ExpenseTypeT: wrap String
     <validations maxLength="1">
-  type EyeColorCodeT: wrap string
+  type EyeColorCodeT: wrap String
     <validations maxLength="3">
-  type FeatureDescrT: wrap string
+  type FeatureDescrT: wrap String
     <validations maxLength="50">
-  type FeatureNameT: wrap string
+  type FeatureNameT: wrap String
     <validations maxLength="10">
-  type FeeWaiverSeqNoT: wrap int
-  type FileLocTypeIDT: wrap int
-  type FileLocationFrameT: wrap string
+  type FeeWaiverSeqNoT: wrap Int
+  type FileLocTypeIDT: wrap Int
+  type FileLocationFrameT: wrap String
     <validations maxLength="20">
-  type FileLocationNoT: wrap int
-  type FileLocationSeqNoT: wrap int
-  type FileLocationTapeT: wrap string
+  type FileLocationNoT: wrap Int
+  type FileLocationSeqNoT: wrap Int
+  type FileLocationTapeT: wrap String
     <validations maxLength="20">
-  type FileNameT: wrap string
+  type FileNameT: wrap String
     <validations maxLength="100">
-  type FileStampTypeT: wrap string
+  type FileStampTypeT: wrap String
     <validations maxLength="3">
-  type FinAgencyTypeT: wrap string
+  type FinAgencyTypeT: wrap String
     <validations maxLength="10">
-  type FinPurgeSeqNoT: wrap int
-  type FineForfSeqNoT: wrap int
-  type FirstNameT: wrap string
+  type FinPurgeSeqNoT: wrap Int
+  type FineForfSeqNoT: wrap Int
+  type FirstNameT: wrap String
     <validations maxLength="30">
-  type FontPreferenceT: wrap string
+  type FontPreferenceT: wrap String
     <validations maxLength="50">
-  type FontT: wrap string
+  type FontT: wrap String
     <validations maxLength="1">
-  type ForgvnMonySeqNoT: wrap int
-  type FormDescriptionT: wrap string
+  type ForgvnMonySeqNoT: wrap Int
+  type FormDescriptionT: wrap String
     <validations maxLength="100">
-  type FormNameT: wrap string
+  type FormNameT: wrap String
     <validations maxLength="255">
-  type FormNumberT: wrap string
-  type FormTypeDescrT: wrap string
+  type FormNumberT: wrap String
+  type FormTypeDescrT: wrap String
     <validations maxLength="20">
-  type FormTypeT: wrap string
+  type FormTypeT: wrap String
     <validations maxLength="3">
-  type FormVersCodeT: wrap string
+  type FormVersCodeT: wrap String
     <validations maxLength="10">
-  type FormulaSeqNoT: wrap int
-  type FullNameT: wrap string
+  type FormulaSeqNoT: wrap Int
+  type FullNameT: wrap String
     <validations maxLength="132">
-  type FunctionalAreaT: wrap string
+  type FunctionalAreaT: wrap String
     <validations maxLength="50">
-  type GenLedAcctT: wrap string
+  type GenLedAcctT: wrap String
     <validations maxLength="30">
-  type GenLetterDocIdT: wrap int
-  type GlClsT: wrap string
+  type GenLetterDocIdT: wrap Int
+  type GlClsT: wrap String
     <validations maxLength="1">
-  type GlobalLinkIdT: wrap int
-  type GracePdT: wrap int
-  type GradYearT: wrap int
-  type HairColorCodeT: wrap string
+  type GlobalLinkIdT: wrap Int
+  type GracePdT: wrap Int
+  type GradYearT: wrap Int
+  type HairColorCodeT: wrap String
     <validations maxLength="3">
-  type HashT: wrap string
+  type HashT: wrap String
     <validations maxLength="40">
-  type HashedSecretT: wrap string
+  type HashedSecretT: wrap String
     <validations maxLength="64">
-  type HexColorT: wrap string
+  type HexColorT: wrap String
     <validations maxLength="6">
-  type HistSeqNoT: wrap int
-  type HolidaySeqNoT: wrap int
-  type HostNameT: wrap string
+  type HistSeqNoT: wrap Int
+  type HolidaySeqNoT: wrap Int
+  type HostNameT: wrap String
     <validations maxLength="10">
-  type HostT: wrap string
+  type HostT: wrap String
     <validations maxLength="50">
-  type HoursServedT: wrap decimal
-  type IBRCodeT: wrap string
+  type HoursServedT: wrap Decimal
+  type IBRCodeT: wrap String
     <validations maxLength="3">
-  type IBRDescrT: wrap string
+  type IBRDescrT: wrap String
     <validations maxLength="100">
-  type ImportExceptionCodeT: wrap string
+  type ImportExceptionCodeT: wrap String
     <validations maxLength="1">
-  type ImportSeqNoT: wrap int
-  type IncrementT: wrap int
-  type InstitutionNameT: wrap string
+  type ImportSeqNoT: wrap Int
+  type IncrementT: wrap Int
+  type InstitutionNameT: wrap String
     <validations maxLength="50">
-  type InstitutionNoT: wrap int
-  type InterceptStatusT: wrap string
+  type InstitutionNoT: wrap Int
+  type InterceptStatusT: wrap String
     <validations maxLength="15">
-  type InterfaceNameT: wrap string
+  type InterfaceNameT: wrap String
     <validations maxLength="20">
-  type InterfaceStatusT: wrap int
-  type IntermedXMLSeqNoT: wrap int
-  type IntprCertLevelT: wrap string
+  type InterfaceStatusT: wrap Int
+  type IntermedXMLSeqNoT: wrap Int
+  type IntprCertLevelT: wrap String
     <validations maxLength="5">
-  type IntprCertLvlDescrT: wrap string
+  type IntprCertLvlDescrT: wrap String
     <validations maxLength="50">
-  type IntprNoT: wrap int
-  type InvoiceCodeDescrT: wrap string
+  type IntprNoT: wrap Int
+  type InvoiceCodeDescrT: wrap String
     <validations maxLength="60">
-  type InvoiceCodeT: wrap string
+  type InvoiceCodeT: wrap String
     <validations maxLength="3">
-  type IpAddressT: wrap string
+  type IpAddressT: wrap String
     <validations maxLength="15">
-  type IssAgencyNmT: wrap string
+  type IssAgencyNmT: wrap String
     <validations maxLength="50">
-  type IssAgencyNoT: wrap int
-  type JAReasonCodeDescrT: wrap string
+  type IssAgencyNoT: wrap Int
+  type JAReasonCodeDescrT: wrap String
     <validations maxLength="50">
-  type JAReasonCodeT: wrap string
+  type JAReasonCodeT: wrap String
     <validations maxLength="5">
-  type JSONT: wrap string
-  type JarFileNameT: wrap string
+  type JSONT: wrap String
+  type JarFileNameT: wrap String
     <validations maxLength="100">
-  type JavaPackageNameT: wrap string
+  type JavaPackageNameT: wrap String
     <validations maxLength="100">
-  type JdgmtLienTypeT: wrap string
+  type JdgmtLienTypeT: wrap String
     <validations maxLength="2">
-  type JdgmtPartyNoT: wrap int
-  type JdgmtPartyStatusT: wrap string
+  type JdgmtPartyNoT: wrap Int
+  type JdgmtPartyStatusT: wrap String
     <validations maxLength="1">
-  type JdgmtPartyTypeT: wrap string
+  type JdgmtPartyTypeT: wrap String
     <validations maxLength="2">
-  type JdgmtSeqNoT: wrap int
-  type JobBatchNoT: wrap int
-  type JobCodeT: wrap string
+  type JdgmtSeqNoT: wrap Int
+  type JobBatchNoT: wrap Int
+  type JobCodeT: wrap String
     <validations maxLength="10">
-  type JobDescrT: wrap string
+  type JobDescrT: wrap String
     <validations maxLength="50">
-  type JobIdT: wrap int
-  type JobNameT: wrap string
+  type JobIdT: wrap Int
+  type JobNameT: wrap String
     <validations maxLength="40">
-  type JobTitleT: wrap string
+  type JobTitleT: wrap String
     <validations maxLength="50">
-  type JointSevAssessNoT: wrap int
-  type JudAssignNoT: wrap string
+  type JointSevAssessNoT: wrap Int
+  type JudAssignNoT: wrap String
     <validations maxLength="12">
-  type JudAssignSeqNoT: wrap int
-  type JudgeNotesT: wrap string
-  type JudgmentIntRateT: wrap decimal
-  type JudgmentPriorityT: wrap int
-  type JurInstrOrdSeqNoT: wrap int
-  type JurisdActionCodeT: wrap string
+  type JudAssignSeqNoT: wrap Int
+  type JudgeNotesT: wrap String
+  type JudgmentIntRateT: wrap Decimal
+  type JudgmentPriorityT: wrap Int
+  type JurInstrOrdSeqNoT: wrap Int
+  type JurisdActionCodeT: wrap String
     <validations maxLength="3">
-  type JurisdActionDescrT: wrap string
+  type JurisdActionDescrT: wrap String
     <validations maxLength="30">
-  type JurorAvailabilityCodeT: wrap string
+  type JurorAvailabilityCodeT: wrap String
     <validations maxLength="5">
-  type JurorCheckInMsgT: wrap string
+  type JurorCheckInMsgT: wrap String
     <validations maxLength="2000">
-  type JurorIdT: wrap int
-  type JurorPostpReqSeqT: wrap int
-  type JurorPostpReqStatT: wrap string
+  type JurorIdT: wrap Int
+  type JurorPostpReqSeqT: wrap Int
+  type JurorPostpReqStatT: wrap String
     <validations maxLength="1">
-  type JurorStatGreetingT: wrap string
+  type JurorStatGreetingT: wrap String
     <validations maxLength="2000">
-  type JurorStatusCodeT: wrap string
+  type JurorStatusCodeT: wrap String
     <validations maxLength="5">
-  type JuryBranchIdT: wrap string
+  type JuryBranchIdT: wrap String
     <validations maxLength="10">
-  type JuryBranchNoT: wrap string
+  type JuryBranchNoT: wrap String
     <validations maxLength="2">
-  type JuryCaseResultT: wrap string
+  type JuryCaseResultT: wrap String
     <validations maxLength="100">
-  type JuryCatSeqNo: wrap int
-  type JuryInstTmplSeqNoT: wrap int
-  type JuryInstrDocTextT: wrap string
-  type JuryInstrNoT: wrap string
+  type JuryCatSeqNo: wrap Int
+  type JuryInstTmplSeqNoT: wrap Int
+  type JuryInstrDocTextT: wrap String
+  type JuryInstrNoT: wrap String
     <validations maxLength="50">
-  type JuryInstrSeqNoT: wrap int
-  type JuryInstrTitleT: wrap string
+  type JuryInstrSeqNoT: wrap Int
+  type JuryInstrTitleT: wrap String
     <validations maxLength="300">
-  type JuryInstrTypeT: wrap string
+  type JuryInstrTypeT: wrap String
     <validations maxLength="1">
-  type JuryReportSeqNoT: wrap int
-  type JurySizeT: wrap int
-  type JuryYearT: wrap string
+  type JuryReportSeqNoT: wrap Int
+  type JurySizeT: wrap Int
+  type JuryYearT: wrap String
     <validations maxLength="4">
-  type JustisNoT: wrap string
+  type JustisNoT: wrap String
     <validations maxLength="8">
-  type KeyEventSeqT: wrap int
-  type LCSubTextT: wrap string
+  type KeyEventSeqT: wrap Int
+  type LCSubTextT: wrap String
     <validations maxLength="50">
-  type LanguageCodeT: wrap string
+  type LanguageCodeT: wrap String
     <validations maxLength="5">
-  type LanguageDescrT: wrap string
+  type LanguageDescrT: wrap String
     <validations maxLength="50">
-  type LanguageNameT: wrap string
+  type LanguageNameT: wrap String
     <validations maxLength="50">
-  type LanguageT: wrap string
+  type LanguageT: wrap String
     <validations maxLength="3">
-  type LastNameT: wrap string
+  type LastNameT: wrap String
     <validations maxLength="60">
-  type LiClassT: wrap string
+  type LiClassT: wrap String
     <validations maxLength="1">
-  type LiEndorsementT: wrap string
+  type LiEndorsementT: wrap String
     <validations maxLength="1">
-  type LineSpacingT: wrap decimal
-  type LinkActionT: wrap string
+  type LineSpacingT: wrap Decimal
+  type LinkActionT: wrap String
     <validations maxLength="6">
-  type LinkDescrT: wrap string
+  type LinkDescrT: wrap String
     <validations maxLength="100">
-  type LinkIdT: wrap int
-  type LinkNameT: wrap string
+  type LinkIdT: wrap Int
+  type LinkNameT: wrap String
     <validations maxLength="50">
-  type LinkTargetT: wrap string
+  type LinkTargetT: wrap String
     <validations maxLength="1000">
-  type LocDescrT: wrap string
+  type LocDescrT: wrap String
     <validations maxLength="100">
-  type LocT: wrap string
+  type LocT: wrap String
     <validations maxLength="50">
-  type LocalGovtNameT: wrap string
+  type LocalGovtNameT: wrap String
     <validations maxLength="60">
-  type LocalGovtSeqNoT: wrap int
-  type LookUpCategoryT: wrap string
+  type LocalGovtSeqNoT: wrap Int
+  type LookUpCategoryT: wrap String
     <validations maxLength="25">
-  type LookUpCodeT: wrap string
+  type LookUpCodeT: wrap String
     <validations maxLength="15">
-  type LookUpDescT: wrap string
+  type LookUpDescT: wrap String
     <validations maxLength="50">
-  type LookUpIDT: wrap int
-  type MD5HashT: wrap string
+  type LookUpIDT: wrap Int
+  type MD5HashT: wrap String
     <validations maxLength="32">
-  type MailCodeT: wrap string
+  type MailCodeT: wrap String
     <validations maxLength="1">
-  type MailDescrT: wrap string
+  type MailDescrT: wrap String
     <validations maxLength="25">
-  type MailServiceTypeT: wrap string
+  type MailServiceTypeT: wrap String
     <validations maxLength="1">
-  type MailingOrderNewT: wrap int
-  type MaintCodeT: wrap string
+  type MailingOrderNewT: wrap Int
+  type MaintCodeT: wrap String
     <validations maxLength="2">
-  type MaritalStatusT: wrap string
+  type MaritalStatusT: wrap String
     <validations maxLength="1">
-  type MasterJurorSeqNoT: wrap int
-  type MaxPmtsToMissT: wrap int
-  type MeasureDescrT: wrap string
+  type MasterJurorSeqNoT: wrap Int
+  type MaxPmtsToMissT: wrap Int
+  type MeasureDescrT: wrap String
     <validations maxLength="100">
-  type MeasureGroupDescrT: wrap string
+  type MeasureGroupDescrT: wrap String
     <validations maxLength="20">
-  type MeasureGroupId: wrap int
-  type MeasureIdT: wrap int
-  type MessageDocSeqNoT: wrap decimal
-  type MessageSeqNoT: wrap decimal
-  type MessageTypeT: wrap string
+  type MeasureGroupId: wrap Int
+  type MeasureIdT: wrap Int
+  type MessageDocSeqNoT: wrap Decimal
+  type MessageSeqNoT: wrap Decimal
+  type MessageTypeT: wrap String
     <validations maxLength="20">
-  type MiddleNameT: wrap string
+  type MiddleNameT: wrap String
     <validations maxLength="30">
-  type MileT: wrap decimal
-  type MileageRateT: wrap decimal
-  type MimeTypeT: wrap string
+  type MileT: wrap Decimal
+  type MileageRateT: wrap Decimal
+  type MimeTypeT: wrap String
     <validations maxLength="10">
-  type MoneyT: wrap decimal
-  type MonthNoNewT: wrap int
-  type MotionDispoCodeT: wrap string
+  type MoneyT: wrap Decimal
+  type MonthNoNewT: wrap Int
+  type MotionDispoCodeT: wrap String
     <validations maxLength="1">
-  type MotionDispoDescrT: wrap string
+  type MotionDispoDescrT: wrap String
     <validations maxLength="10">
-  type MunicipalityCodeT: wrap string
+  type MunicipalityCodeT: wrap String
     <validations maxLength="7">
-  type MunicipalityDescT: wrap string
+  type MunicipalityDescT: wrap String
     <validations maxLength="50">
-  type MunicipalityIDT: wrap int
-  type NCICAgencyIdT: wrap string
+  type MunicipalityIDT: wrap Int
+  type NCICAgencyIdT: wrap String
     <validations maxLength="9">
-  type NCICCodeT: wrap string
+  type NCICCodeT: wrap String
     <validations maxLength="4">
-  type NCICDescrT: wrap string
+  type NCICDescrT: wrap String
     <validations maxLength="80">
-  type NameInfoT: wrap string
+  type NameInfoT: wrap String
     <validations maxLength="60">
-  type NamePrefixT: wrap string
+  type NamePrefixT: wrap String
     <validations maxLength="4">
-  type NameSuffixT: wrap string
+  type NameSuffixT: wrap String
     <validations maxLength="3">
-  type NewPartyAKASeqNoT: wrap decimal
-  type NewPartyAttySeqNoT: wrap decimal
-  type NoJurorT: wrap int
-  type NotcAgencyCodeT: wrap string
+  type NewPartyAKASeqNoT: wrap Decimal
+  type NewPartyAttySeqNoT: wrap Decimal
+  type NoJurorT: wrap Int
+  type NotcAgencyCodeT: wrap String
     <validations maxLength="5">
-  type NotcRecEmAudSeqNoT: wrap int
-  type NotcRecFromSeqNoT: wrap int
-  type NotcRecipEStatusT: wrap string
+  type NotcRecEmAudSeqNoT: wrap Int
+  type NotcRecFromSeqNoT: wrap Int
+  type NotcRecipEStatusT: wrap String
     <validations maxLength="1">
-  type NotcRecipSeqNoT: wrap int
-  type NotesT: wrap string
+  type NotcRecipSeqNoT: wrap Int
+  type NotesT: wrap String
     <validations maxLength="255">
-  type NumDaysNewT: wrap decimal
-  type OccupationT: wrap string
+  type NumDaysNewT: wrap Decimal
+  type OccupationT: wrap String
     <validations maxLength="100">
-  type OffenseDateRangeT: wrap string
+  type OffenseDateRangeT: wrap String
     <validations maxLength="100">
-  type OfficerIdT: wrap string
+  type OfficerIdT: wrap String
     <validations maxLength="10">
-  type OfficerSeqNoT: wrap int
-  type OnHighwayT: wrap string
+  type OfficerSeqNoT: wrap Int
+  type OnHighwayT: wrap String
     <validations maxLength="255">
-  type OpClassT: wrap string
+  type OpClassT: wrap String
     <validations maxLength="1">
-  type OpEndorsementT: wrap string
+  type OpEndorsementT: wrap String
     <validations maxLength="1">
-  type OperLicNoT: wrap string
+  type OperLicNoT: wrap String
     <validations maxLength="25">
-  type OrderSeqNoT: wrap int
-  type OrderTypeCodeT: wrap string
+  type OrderSeqNoT: wrap Int
+  type OrderTypeCodeT: wrap String
     <validations maxLength="2">
-  type OrderTypeT: wrap string
+  type OrderTypeT: wrap String
     <validations maxLength="3">
-  type OrganizationCodeT: wrap string
+  type OrganizationCodeT: wrap String
     <validations maxLength="5">
-  type PRDSeqNoT: wrap int
-  type PageAnnotateSeqNoT: wrap int
-  type PageNoT: wrap int
-  type PanelDescrT: wrap string
+  type PRDSeqNoT: wrap Int
+  type PageAnnotateSeqNoT: wrap Int
+  type PageNoT: wrap Int
+  type PanelDescrT: wrap String
     <validations maxLength="50">
-  type PanelIdT: wrap string
+  type PanelIdT: wrap String
     <validations maxLength="10">
-  type PanelMemberNoT: wrap int
-  type PanelRandomNoT: wrap int
-  type PartyNoT: wrap int
-  type PartySeqNoT: wrap decimal
-  type PartyTypeCodeT: wrap string
+  type PanelMemberNoT: wrap Int
+  type PanelRandomNoT: wrap Int
+  type PartyNoT: wrap Int
+  type PartySeqNoT: wrap Decimal
+  type PartyTypeCodeT: wrap String
     <validations maxLength="3">
-  type PartyTypeDescrT: wrap string
+  type PartyTypeDescrT: wrap String
     <validations maxLength="35">
-  type PartyTypeT: wrap string
+  type PartyTypeT: wrap String
     <validations maxLength="2">
-  type PayableNoT: wrap int
-  type PayableSeqNoT: wrap int
-  type PaymentChannelT: wrap string
+  type PayableNoT: wrap Int
+  type PayableSeqNoT: wrap Int
+  type PaymentChannelT: wrap String
     <validations maxLength="5">
-  type PaymentDeferCodeT: wrap string
+  type PaymentDeferCodeT: wrap String
     <validations maxLength="3">
-  type PaymentMethodT: wrap string
+  type PaymentMethodT: wrap String
     <validations maxLength="3">
-  type PaymentStatusT: wrap string
+  type PaymentStatusT: wrap String
     <validations maxLength="4">
-  type PctCoordinateT: wrap decimal
-  type PdCodeT: wrap string
+  type PctCoordinateT: wrap Decimal
+  type PdCodeT: wrap String
     <validations maxLength="2">
-  type PenaltyStatuteT: wrap string
+  type PenaltyStatuteT: wrap String
     <validations maxLength="21">
-  type PendingCaseSeqNoT: wrap int
-  type PercentageT: wrap decimal
-  type PeremptoryNoT: wrap int
-  type PeriodSeqNoT: wrap int
-  type PermRevMethDescrT: wrap string
+  type PendingCaseSeqNoT: wrap Int
+  type PercentageT: wrap Decimal
+  type PeremptoryNoT: wrap Int
+  type PeriodSeqNoT: wrap Int
+  type PermRevMethDescrT: wrap String
     <validations maxLength="30">
-  type PermReviewMethodT: wrap int
-  type PermReviewSeqNoT: wrap int
-  type PersonIDT: wrap int
-  type PersonRoleCodeT: wrap int
-  type PersonRoleIDT: wrap int
-  type PhoneExtT: wrap string
+  type PermReviewMethodT: wrap Int
+  type PermReviewSeqNoT: wrap Int
+  type PersonIDT: wrap Int
+  type PersonRoleCodeT: wrap Int
+  type PersonRoleIDT: wrap Int
+  type PhoneExtT: wrap String
     <validations maxLength="5">
-  type PhoneIDT: wrap int
-  type PhoneIntlT: wrap string
+  type PhoneIDT: wrap Int
+  type PhoneIntlT: wrap String
     <validations maxLength="25">
-  type PhoneT: wrap string
+  type PhoneT: wrap String
     <validations maxLength="12">
-  type PlaceEndTypeDescrT: wrap string
+  type PlaceEndTypeDescrT: wrap String
     <validations maxLength="40">
-  type PlaceSettingDescrT: wrap string
+  type PlaceSettingDescrT: wrap String
     <validations maxLength="40">
-  type PlacementEndTypeT: wrap int
-  type PlacementReasDescT: wrap string
+  type PlacementEndTypeT: wrap Int
+  type PlacementReasDescT: wrap String
     <validations maxLength="40">
-  type PlacementReasonT: wrap int
-  type PlacementSettingT: wrap int
-  type PleaCodeT: wrap string
+  type PlacementReasonT: wrap Int
+  type PlacementSettingT: wrap Int
+  type PleaCodeT: wrap String
     <validations maxLength="4">
-  type PleaPriorityT: wrap int
-  type PlntfAgencyNmT: wrap string
+  type PleaPriorityT: wrap Int
+  type PlntfAgencyNmT: wrap String
     <validations maxLength="50">
-  type PlntfAgencyNoT: wrap int
-  type PlntfAgencyTypeT: wrap string
+  type PlntfAgencyNoT: wrap Int
+  type PlntfAgencyTypeT: wrap String
     <validations maxLength="1">
-  type PmtMethodT: wrap string
+  type PmtMethodT: wrap String
     <validations maxLength="1">
-  type PmtPriorityT: wrap int
-  type PoolDescrT: wrap string
+  type PmtPriorityT: wrap Int
+  type PoolDescrT: wrap String
     <validations maxLength="50">
-  type PoolIdT: wrap string
+  type PoolIdT: wrap String
     <validations maxLength="10">
-  type PoolImportStatusT: wrap string
+  type PoolImportStatusT: wrap String
     <validations maxLength="1">
-  type PoolMemberNoT: wrap int
-  type PoolRequestDocNameT: wrap string
+  type PoolMemberNoT: wrap Int
+  type PoolRequestDocNameT: wrap String
     <validations maxLength="50">
-  type PoolRequestSeqNoT: wrap int
-  type PopulationT: wrap int
-  type PortT: wrap int
-  type PositionT: wrap decimal
-  type PostponeReasonT: wrap string
-  type PrefNameT: wrap string
+  type PoolRequestSeqNoT: wrap Int
+  type PopulationT: wrap Int
+  type PortT: wrap Int
+  type PositionT: wrap Decimal
+  type PostponeReasonT: wrap String
+  type PrefNameT: wrap String
     <validations maxLength="100">
-  type PrimAddrT: wrap string
+  type PrimAddrT: wrap String
     <validations maxLength="50">
-  type PrintStatusT: wrap string
+  type PrintStatusT: wrap String
     <validations maxLength="255">
-  type PrinterNameT: wrap string
+  type PrinterNameT: wrap String
     <validations maxLength="31">
-  type PriorityT: wrap int
-  type PrisonerIdT: wrap string
+  type PriorityT: wrap Int
+  type PrisonerIdT: wrap String
     <validations maxLength="12">
-  type ProHacViceAttyNoT: wrap string
+  type ProHacViceAttyNoT: wrap String
     <validations maxLength="30">
-  type ProSeNoT: wrap int
-  type ProsAgencyNmT: wrap string
+  type ProSeNoT: wrap Int
+  type ProsAgencyNmT: wrap String
     <validations maxLength="50">
-  type ProsAgencyNoT: wrap int
-  type ProtOrdActionTypeT: wrap string
+  type ProsAgencyNoT: wrap Int
+  type ProtOrdActionTypeT: wrap String
     <validations maxLength="1">
-  type ProtOrdActnDescrT: wrap string
+  type ProtOrdActnDescrT: wrap String
     <validations maxLength="20">
-  type ProtOrderSeqNoT: wrap int
-  type PrtEngineCodeT: wrap string
+  type ProtOrderSeqNoT: wrap Int
+  type PrtEngineCodeT: wrap String
     <validations maxLength="3">
-  type PublicOptInCodeT: wrap string
+  type PublicOptInCodeT: wrap String
     <validations maxLength="6">
-  type QueryNameT: wrap string
+  type QueryNameT: wrap String
     <validations maxLength="255">
-  type QuestionSeqNoT: wrap int
-  type QueueNameT: wrap string
+  type QuestionSeqNoT: wrap Int
+  type QueueNameT: wrap String
     <validations maxLength="32">
-  type RaceCodeT: wrap string
+  type RaceCodeT: wrap String
     <validations maxLength="1">
-  type RcptSchedSeqNoT: wrap int
-  type RcptTypeCodeT: wrap string
+  type RcptSchedSeqNoT: wrap Int
+  type RcptTypeCodeT: wrap String
     <validations maxLength="1">
-  type RcvblAcctDescrT: wrap string
+  type RcvblAcctDescrT: wrap String
     <validations maxLength="20">
-  type RcvblAcctTypeT: wrap string
+  type RcvblAcctTypeT: wrap String
     <validations maxLength="1">
-  type RcvblNoT: wrap int
-  type ReasonCodeT: wrap string
+  type RcvblNoT: wrap Int
+  type ReasonCodeT: wrap String
     <validations maxLength="3">
-  type RecommendCodeT: wrap string
+  type RecommendCodeT: wrap String
     <validations maxLength="1">
-  type RecommendDescrT: wrap string
+  type RecommendDescrT: wrap String
     <validations maxLength="20">
-  type RecordTypeT: wrap string
+  type RecordTypeT: wrap String
     <validations maxLength="2">
-  type RecordingLocationT: wrap string
+  type RecordingLocationT: wrap String
     <validations maxLength="100">
-  type RecurCalSeqNoT: wrap int
-  type RecurHolidaySeqNoT: wrap int
-  type RecurTimeBlkSeqNoT: wrap int
-  type RedactAttemptNoT: wrap int
-  type RegExValidationT: wrap string
-  type RejectionCodeT: wrap string
+  type RecurCalSeqNoT: wrap Int
+  type RecurHolidaySeqNoT: wrap Int
+  type RecurTimeBlkSeqNoT: wrap Int
+  type RedactAttemptNoT: wrap Int
+  type RegExValidationT: wrap String
+  type RejectionCodeT: wrap String
     <validations maxLength="10">
-  type RelSeqNoT: wrap int
-  type RelationIdT: wrap int
-  type RelationshipCodeT: wrap string
+  type RelSeqNoT: wrap Int
+  type RelationIdT: wrap Int
+  type RelationshipCodeT: wrap String
     <validations maxLength="2">
-  type RelationshipDescrT: wrap string
+  type RelationshipDescrT: wrap String
     <validations maxLength="40">
-  type ReportIdT: wrap string
+  type ReportIdT: wrap String
     <validations maxLength="10">
-  type ReportMethodCodeT: wrap string
+  type ReportMethodCodeT: wrap String
     <validations maxLength="3">
-  type ReportNameT: wrap string
+  type ReportNameT: wrap String
     <validations maxLength="40">
-  type ReportNoT: wrap int
-  type ReportTypeT: wrap string
+  type ReportNoT: wrap Int
+  type ReportTypeT: wrap String
     <validations maxLength="1">
-  type ReqAgencyNoT: wrap int
-  type ReviewMessageT: wrap string
+  type ReqAgencyNoT: wrap Int
+  type ReviewMessageT: wrap String
     <validations maxLength="500">
-  type ReviewSeqNoT: wrap int
-  type RngDaPrtyAliasSeqT: wrap int
-  type RoomSeqNoT: wrap int
-  type RowOrderT: wrap int
-  type RptrStatusCodeT: wrap string
+  type ReviewSeqNoT: wrap Int
+  type RngDaPrtyAliasSeqT: wrap Int
+  type RoomSeqNoT: wrap Int
+  type RowOrderT: wrap Int
+  type RptrStatusCodeT: wrap String
     <validations maxLength="1">
-  type RptrStatusDescrT: wrap string
+  type RptrStatusDescrT: wrap String
     <validations maxLength="25">
-  type RungCorrTypeIdT: wrap string
+  type RungCorrTypeIdT: wrap String
     <validations maxLength="50">
-  type RungDaChargeSeqNoT: wrap int
-  type RungDaCitnSeqNoT: wrap int
-  type RungDaPartySeqNoT: wrap int
-  type RungHostIdT: wrap string
+  type RungDaChargeSeqNoT: wrap Int
+  type RungDaCitnSeqNoT: wrap Int
+  type RungDaPartySeqNoT: wrap Int
+  type RungHostIdT: wrap String
     <validations maxLength="25">
-  type RungStatusT: wrap string
+  type RungStatusT: wrap String
     <validations maxLength="1">
-  type RungUserIdT: wrap string
+  type RungUserIdT: wrap String
     <validations maxLength="32">
-  type SDCAddressT: wrap string
+  type SDCAddressT: wrap String
     <validations maxLength="40">
-  type SDCAgencyIdT: wrap string
+  type SDCAgencyIdT: wrap String
     <validations maxLength="6">
-  type SDCCityT: wrap string
+  type SDCCityT: wrap String
     <validations maxLength="22">
-  type SDCFirstNameT: wrap string
+  type SDCFirstNameT: wrap String
     <validations maxLength="20">
-  type SDCLastNameT: wrap string
+  type SDCLastNameT: wrap String
     <validations maxLength="32">
-  type SDCOperLicNoT: wrap string
+  type SDCOperLicNoT: wrap String
     <validations maxLength="14">
-  type SDCSsnT: wrap string
+  type SDCSsnT: wrap String
     <validations maxLength="9">
-  type SalesTaxPctT: wrap decimal
-  type SatisfactionT: wrap string
+  type SalesTaxPctT: wrap Decimal
+  type SatisfactionT: wrap String
     <validations maxLength="1">
-  type ScanHistSeqNoT: wrap int
-  type ScannedDocSeqNoT: wrap int
-  type SccaCaseNoT: wrap string
+  type ScanHistSeqNoT: wrap Int
+  type ScannedDocSeqNoT: wrap Int
+  type SccaCaseNoT: wrap String
     <validations maxLength="14">
-  type SchedCodeT: wrap string
+  type SchedCodeT: wrap String
     <validations maxLength="5">
-  type SchedDescrT: wrap string
+  type SchedDescrT: wrap String
     <validations maxLength="25">
-  type ScreenNameT: wrap string
+  type ScreenNameT: wrap String
     <validations maxLength="50">
-  type ScvCodeT: wrap string
+  type ScvCodeT: wrap String
     <validations maxLength="2">
-  type SearchNameT: wrap string
+  type SearchNameT: wrap String
     <validations maxLength="125">
-  type SearchStatuteCiteT: wrap string
+  type SearchStatuteCiteT: wrap String
     <validations maxLength="30">
-  type SearchWarrantSeqNoT: wrap int
-  type SeatChartSeqNoT: wrap int
-  type SecAddrT: wrap string
+  type SearchWarrantSeqNoT: wrap Int
+  type SeatChartSeqNoT: wrap Int
+  type SecAddrT: wrap String
     <validations maxLength="50">
-  type SectionNoT: wrap int
-  type SentCodeT: wrap string
+  type SectionNoT: wrap Int
+  type SentCodeT: wrap String
     <validations maxLength="4">
-  type SentToT: wrap string
+  type SentToT: wrap String
     <validations maxLength="100">
-  type SentencePriorityT: wrap int
-  type SeqNoT: wrap int
-  type SequentialIdT: wrap string
+  type SentencePriorityT: wrap Int
+  type SeqNoT: wrap Int
+  type SequentialIdT: wrap String
     <validations maxLength="50">
-  type SevClsCodeT: wrap string
+  type SevClsCodeT: wrap String
     <validations maxLength="2">
-  type SexCodeT: wrap string
+  type SexCodeT: wrap String
     <validations maxLength="1">
-  type SignatureT: wrap string
+  type SignatureT: wrap String
     <validations maxLength="50">
-  type SmsMessageNoT: wrap int
-  type SortOrderNoT: wrap int
-  type SortTypeT: wrap string
+  type SmsMessageNoT: wrap Int
+  type SortOrderNoT: wrap Int
+  type SortTypeT: wrap String
     <validations maxLength="4">
-  type SoundexT: wrap string
+  type SoundexT: wrap String
     <validations maxLength="4">
-  type SpclNotcSeqNoT: wrap int
-  type SpeakerT: wrap string
+  type SpclNotcSeqNoT: wrap Int
+  type SpeakerT: wrap String
     <validations maxLength="125">
-  type Ssn2T: wrap string
+  type Ssn2T: wrap String
     <validations maxLength="25">
-  type Ssn3T: wrap string
+  type Ssn3T: wrap String
     <validations maxLength="11">
-  type StampActionT: wrap string
+  type StampActionT: wrap String
     <validations maxLength="1">
-  type StampLineT: wrap string
+  type StampLineT: wrap String
     <validations maxLength="22">
-  type StampTypeT: wrap string
+  type StampTypeT: wrap String
     <validations maxLength="3">
-  type StatIBRCodeSeqNoT: wrap int
-  type StatNCICCodeSeqNoT: wrap int
-  type StatReportSeqNoT: wrap int
-  type StatRowNameT: wrap string
+  type StatIBRCodeSeqNoT: wrap Int
+  type StatNCICCodeSeqNoT: wrap Int
+  type StatReportSeqNoT: wrap Int
+  type StatRowNameT: wrap String
     <validations maxLength="50">
-  type StatUCRACodeSeqNoT: wrap int
-  type StatUCRRtACdSeqNoT: wrap int
-  type StateDescT: wrap string
+  type StatUCRACodeSeqNoT: wrap Int
+  type StatUCRRtACdSeqNoT: wrap Int
+  type StateDescT: wrap String
     <validations maxLength="50">
-  type StateIdT: wrap int
-  type StateT: wrap string
+  type StateIdT: wrap Int
+  type StateT: wrap String
     <validations maxLength="2">
-  type StatusCodeT: wrap string
+  type StatusCodeT: wrap String
     <validations maxLength="2">
-  type StatuteCiteT: wrap string
+  type StatuteCiteT: wrap String
     <validations maxLength="21">
-  type StatuteDescrT: wrap string
+  type StatuteDescrT: wrap String
     <validations maxLength="100">
-  type StatuteSevSeqNoT: wrap int
-  type StatuteTypeT: wrap string
+  type StatuteSevSeqNoT: wrap Int
+  type StatuteTypeT: wrap String
     <validations maxLength="1">
-  type StepAgencyCodeT: wrap string
+  type StepAgencyCodeT: wrap String
     <validations maxLength="5">
-  type StepAgencyDescrT: wrap string
+  type StepAgencyDescrT: wrap String
     <validations maxLength="35">
-  type StepDOJSeqNoT: wrap int
-  type StepImportStatusT: wrap string
+  type StepDOJSeqNoT: wrap Int
+  type StepImportStatusT: wrap String
     <validations maxLength="1">
-  type SupDurationT: wrap int
-  type SuperAgencyNmT: wrap string
+  type SupDurationT: wrap Int
+  type SuperAgencyNmT: wrap String
     <validations maxLength="50">
-  type SuperAgencyNoT: wrap string
+  type SuperAgencyNoT: wrap String
     <validations maxLength="3">
-  type SupportingDocSeqNoT: wrap int
-  type SyncSeqNoT: wrap int
-  type TableNameT: wrap string
+  type SupportingDocSeqNoT: wrap Int
+  type SyncSeqNoT: wrap Int
+  type TableNameT: wrap String
     <validations maxLength="30">
-  type TagDescr: wrap string
+  type TagDescr: wrap String
     <validations maxLength="50">
-  type TagDocAutoDescrT: wrap string
+  type TagDocAutoDescrT: wrap String
     <validations maxLength="100">
-  type TagDocAutoIdT: wrap int
-  type TagDocSeqNoT: wrap int
-  type TagNameT: wrap string
+  type TagDocAutoIdT: wrap Int
+  type TagDocSeqNoT: wrap Int
+  type TagNameT: wrap String
     <validations maxLength="25">
-  type TagTypeT: wrap string
+  type TagTypeT: wrap String
     <validations maxLength="2">
-  type TapeCounterNoT: wrap string
+  type TapeCounterNoT: wrap String
     <validations maxLength="16">
-  type TapeLocT: wrap string
+  type TapeLocT: wrap String
     <validations maxLength="18">
-  type TempAccessCodeT: wrap string
+  type TempAccessCodeT: wrap String
     <validations maxLength="12">
-  type TenderCodeT: wrap string
+  type TenderCodeT: wrap String
     <validations maxLength="2">
-  type TenderSeqNoT: wrap int
-  type TextT: wrap string
+  type TenderSeqNoT: wrap Int
+  type TextT: wrap String
     <validations maxLength="2000">
-  type ThrottleIdT: wrap string
+  type ThrottleIdT: wrap String
     <validations maxLength="50">
-  type TimeBlkTpSeqNoT: wrap int
-  type TimeBlockSeqNoT: wrap int
+  type TimeBlkTpSeqNoT: wrap Int
+  type TimeBlockSeqNoT: wrap Int
   type TimeT: wrap DateTimeSupport.Time
   type TimestampT: wrap DateTimeSupport.Timestamp
-  type TitleT: wrap string
+  type TitleT: wrap String
     <validations maxLength="25">
-  type TranDetailSeqNoT: wrap int
-  type TranIdSeqNoT: wrap int
-  type TranIdT: wrap string
+  type TranDetailSeqNoT: wrap Int
+  type TranIdSeqNoT: wrap Int
+  type TranIdT: wrap String
     <validations maxLength="12">
-  type TranImageSeqNoT: wrap decimal
-  type TranNoT: wrap int
-  type TranTypeT: wrap string
+  type TranImageSeqNoT: wrap Decimal
+  type TranNoT: wrap Int
+  type TranTypeT: wrap String
     <validations maxLength="1">
-  type TranscriptCodeT: wrap string
+  type TranscriptCodeT: wrap String
     <validations maxLength="1">
-  type TranscriptDescrT: wrap string
+  type TranscriptDescrT: wrap String
     <validations maxLength="25">
-  type TriggeredCalNameT: wrap string
+  type TriggeredCalNameT: wrap String
     <validations maxLength="100">
-  type TriggeredCalSeqNoT: wrap int
-  type TripCodeDescrT: wrap string
+  type TriggeredCalSeqNoT: wrap Int
+  type TripCodeDescrT: wrap String
     <validations maxLength="30">
-  type TripCodeT: wrap string
+  type TripCodeT: wrap String
     <validations maxLength="5">
-  type TripErrDescrT: wrap string
+  type TripErrDescrT: wrap String
     <validations maxLength="255">
-  type TripHistSeqNoT: wrap int
-  type TripSeqNoT: wrap int
-  type UCRACodeT: wrap string
+  type TripHistSeqNoT: wrap Int
+  type TripSeqNoT: wrap Int
+  type UCRACodeT: wrap String
     <validations maxLength="3">
-  type UCRADescrT: wrap string
+  type UCRADescrT: wrap String
     <validations maxLength="100">
-  type UCRRtACdT: wrap string
+  type UCRRtACdT: wrap String
     <validations maxLength="3">
-  type UCRRtADescrT: wrap string
+  type UCRRtADescrT: wrap String
     <validations maxLength="100">
-  type URLT: wrap string
+  type URLT: wrap String
     <validations maxLength="255">
-  type UUIDT: wrap string
+  type UUIDT: wrap String
     <validations maxLength="36">
-  type UnifiedCaseNoT: wrap string
+  type UnifiedCaseNoT: wrap String
     <validations maxLength="14">
-  type UpdateTypeIdT: wrap int
-  type UserBarCodeNoT: wrap int
-  type UserBarCodeTypeNoT: wrap int
-  type UserIdT: wrap string
+  type UpdateTypeIdT: wrap Int
+  type UserBarCodeNoT: wrap Int
+  type UserBarCodeTypeNoT: wrap Int
+  type UserIdT: wrap String
     <validations maxLength="8">
-  type VersionNoT: wrap string
+  type VersionNoT: wrap String
     <validations maxLength="10">
-  type VersionT: wrap string
+  type VersionT: wrap String
     <validations maxLength="20">
-  type VoirDireNameT: wrap string
+  type VoirDireNameT: wrap String
     <validations maxLength="50">
-  type VoirDireSeqNoT: wrap int
-  type VoteCodeT: wrap string
+  type VoirDireSeqNoT: wrap Int
+  type VoteCodeT: wrap String
     <validations maxLength="1">
-  type VoteDescrT: wrap string
+  type VoteDescrT: wrap String
     <validations maxLength="20">
-  type WarrantSeqNoT: wrap int
-  type WarrantTypeT: wrap string
+  type WarrantSeqNoT: wrap Int
+  type WarrantTypeT: wrap String
     <validations maxLength="2">
-  type WccaAgencyNameT: wrap string
+  type WccaAgencyNameT: wrap String
     <validations maxLength="50">
-  type WccaCommentsT: wrap string
+  type WccaCommentsT: wrap String
     <validations maxLength="255">
-  type WccaPasswordT: wrap string
+  type WccaPasswordT: wrap String
     <validations maxLength="32">
-  type WccaProfileNameT: wrap string
+  type WccaProfileNameT: wrap String
     <validations maxLength="50">
-  type WccaTimeBlkSeqNoT: wrap int
-  type WccaTitleT: wrap string
+  type WccaTimeBlkSeqNoT: wrap Int
+  type WccaTitleT: wrap String
     <validations maxLength="50">
-  type WccaUserNameT: wrap string
+  type WccaUserNameT: wrap String
     <validations maxLength="32">
-  type WccaUserTypeT: wrap string
+  type WccaUserTypeT: wrap String
     <validations maxLength="32">
-  type WcisActivityCodeT: wrap string
+  type WcisActivityCodeT: wrap String
     <validations maxLength="3">
-  type WcisChrgDispoCodeT: wrap string
+  type WcisChrgDispoCodeT: wrap String
     <validations maxLength="2">
-  type WcisClsCodeT: wrap string
+  type WcisClsCodeT: wrap String
     <validations maxLength="5">
-  type WcisClsDescrT: wrap string
+  type WcisClsDescrT: wrap String
     <validations maxLength="40">
-  type WcisClsJudgeTypeT: wrap string
+  type WcisClsJudgeTypeT: wrap String
     <validations maxLength="1">
-  type WcisCondTypeT: wrap string
+  type WcisCondTypeT: wrap String
     <validations maxLength="1">
-  type WcisSentCodeT: wrap string
+  type WcisSentCodeT: wrap String
     <validations maxLength="4">
-  type WcisSpecStatusT: wrap string
+  type WcisSpecStatusT: wrap String
     <validations maxLength="3">
-  type WeightedRandomT: wrap decimal
-  type WithdrawalOrdDescT: wrap string
+  type WeightedRandomT: wrap Decimal
+  type WithdrawalOrdDescT: wrap String
     <validations maxLength="50">
-  type WithdrwlOrdBasisT: wrap string
+  type WithdrwlOrdBasisT: wrap String
     <validations maxLength="3">
-  type WitnessSeqNoT: wrap int
-  type WitnessTypeT: wrap string
+  type WitnessSeqNoT: wrap Int
+  type WitnessTypeT: wrap String
     <validations maxLength="1">
-  type WorkstationIdT: wrap string
+  type WorkstationIdT: wrap String
     <validations maxLength="10">
-  type XMLIntT: wrap int
-  type XMLSeqNoT: wrap int
-  type XMLStringValueT: wrap string
+  type XMLIntT: wrap Int
+  type XMLSeqNoT: wrap Int
+  type XMLStringValueT: wrap String
     <validations maxLength="255">
-  type XMLTagNameT: wrap string
+  type XMLTagNameT: wrap String
     <validations maxLength="255">
-  type XmlNameT: wrap string
+  type XmlNameT: wrap String
     <validations maxLength="40">
-  type XmlT: wrap string
-  type XmlUsageT: wrap string
+  type XmlT: wrap String
+  type XmlUsageT: wrap String
     <validations maxLength="20">
-  type YearNoT: wrap int
-  type ZipCodeT: wrap string
+  type YearNoT: wrap Int
+  type ZipCodeT: wrap String
     <validations maxLength="10">
-  type ZipT: wrap string
+  type ZipT: wrap String
     <validations maxLength="10">
-  type ZoneT: wrap string
+  type ZoneT: wrap String
     <validations maxLength="1">
 }

--- a/src/Ccap/Codegen/PrettyPrint.purs
+++ b/src/Ccap/Codegen/PrettyPrint.purs
@@ -36,10 +36,10 @@ trailingSpace boxes =
 primitive :: Primitive -> Box
 primitive p = text
   case p of
-    PBoolean -> "boolean"
-    PInt -> "int"
-    PDecimal -> "decimal"
-    PString -> "string"
+    PBoolean -> "Boolean"
+    PInt -> "Int"
+    PDecimal -> "Decimal"
+    PString -> "String"
 
 indented :: Box -> Box
 indented b = emptyBox 0 2 <<>> b
@@ -84,5 +84,5 @@ tyType = case _ of
   Primitive p -> primitive p
   Ref _ { mod: Nothing, typ } -> text typ
   Ref _ { mod: Just m, typ } -> text (m <> "." <> typ)
-  Array t -> text "array" <<+>> tyType t
-  Option t ->  text "optional" <<+>> tyType t
+  Array t -> text "Array" <<+>> tyType t
+  Option t ->  text "Maybe" <<+>> tyType t


### PR DESCRIPTION
Making them consistent with user-defined types