### PR TITLE
Enforce single module per file

### DIFF
--- a/samples/County.tmpl
+++ b/samples/County.tmpl
@@ -2,7 +2,7 @@
  * An example template file
  */
 
-// - A template file consists of one or more modules.
+// - A template file consists of one module.
 // - A module consists of one or more type declarations.
 // - Non-primitive type and module names are camel-case with an initial upper-case letter.
 // - Any type can be marked as Maybe (Maybe in PureScript, Option in Scala)

--- a/src/Ccap/Codegen/Parser.purs
+++ b/src/Ccap/Codegen/Parser.purs
@@ -9,7 +9,7 @@ import Prelude
 import Ccap.Codegen.PrettyPrint (prettyPrint) as PrettyPrinter
 import Ccap.Codegen.Types (Annotation(..), AnnotationParam(..), Module(..), Primitive(..), RecordProp(..), TRef, TopType(..), Type(..), TypeDecl(..))
 import Control.Alt ((<|>))
-import Data.Array (fromFoldable, many, some) as Array
+import Data.Array (fromFoldable, many) as Array
 import Data.Char.Unicode (isLower)
 import Data.Either (Either)
 import Data.Foldable (intercalate)
@@ -147,8 +147,8 @@ annotationParam = ado
   value <- option Nothing (lexeme (char '=') *> stringLiteral <#> Just)
   in AnnotationParam name pos value
 
-wholeFile :: ParserT String Identity (Array Module)
-wholeFile = whiteSpace *> Array.some oneModule
+wholeFile :: ParserT String Identity Module
+wholeFile = whiteSpace *> oneModule
 
 errorMessage :: String -> ParseError -> String
 errorMessage fileName err =
@@ -163,11 +163,11 @@ errorMessage fileName err =
       <> ": "
       <> parseErrorMessage err
 
-roundTrip :: Array Module -> Either ParseError Boolean
-roundTrip modules1 = do
-  let prettyPrinted1 = PrettyPrinter.prettyPrint modules1
-  modules2 <- runParser prettyPrinted1 wholeFile
-  let prettyPrinted2 = PrettyPrinter.prettyPrint modules2
+roundTrip :: Module -> Either ParseError Boolean
+roundTrip module1 = do
+  let prettyPrinted1 = PrettyPrinter.prettyPrint module1
+  module2 <- runParser prettyPrinted1 wholeFile
+  let prettyPrinted2 = PrettyPrinter.prettyPrint module2
   pure $ prettyPrinted1 == prettyPrinted2
 
 

--- a/src/Ccap/Codegen/PrettyPrint.purs
+++ b/src/Ccap/Codegen/PrettyPrint.purs
@@ -9,12 +9,11 @@ import Ccap.Codegen.Shared (OutputSpec)
 import Ccap.Codegen.Types (Annotation(..), AnnotationParam(..), Module(..), Primitive(..), RecordProp(..), TopType(..), Type(..), TypeDecl(..))
 import Data.Array as Array
 import Data.Maybe (Maybe(..), maybe)
-import Text.PrettyPrint.Boxes (Box, char, emptyBox, hsep, render, text, vcat, vsep, (//), (<<+>>), (<<>>))
+import Text.PrettyPrint.Boxes (Box, char, emptyBox, hsep, render, text, vcat, (//), (<<+>>), (<<>>))
 import Text.PrettyPrint.Boxes (left, top) as Boxes
 
-prettyPrint :: Array Module -> String
-prettyPrint modules =
-  render $ vsep 1 Boxes.left (modules <#> oneModule)
+prettyPrint :: Module -> String
+prettyPrint = render <<< oneModule
 
 outputSpec :: OutputSpec
 outputSpec =


### PR DESCRIPTION
Next: Remove explicit `module` and indentation