### PR TITLE
Fix internal references and validations

### DIFF
--- a/src/Ccap/Codegen/Util.purs
+++ b/src/Ccap/Codegen/Util.purs
@@ -3,8 +3,10 @@ module Ccap.Codegen.Util where
 import Prelude
 import Control.Monad.Error.Class (try)
 import Control.Monad.Except (ExceptT(..), runExceptT)
+import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
 import Data.Bifunctor (lmap)
 import Data.Either (either)
+import Data.Maybe (Maybe, fromMaybe)
 import Data.String.Regex (regex)
 import Data.String.Regex (replace) as Regex
 import Data.String.Regex.Flags (global, multiline) as Regex.Flags
@@ -43,3 +45,9 @@ scrubEolSpaces i =
 --| Ensure newline
 ensureNewline :: String -> String
 ensureNewline s = if String.endsWith "\n" s then s else s <> "\n"
+
+maybeT :: forall f a. Applicative f => Maybe a -> MaybeT f a
+maybeT = MaybeT <<< pure
+
+fromMaybeT :: forall f a. Functor f => a -> MaybeT f a -> f a
+fromMaybeT a = map (fromMaybe a) <<< runMaybeT

--- a/test/Ccap/Codegen/Exports.purs
+++ b/test/Ccap/Codegen/Exports.purs
@@ -6,11 +6,9 @@ import Prelude
 import Ccap.Codegen.Purescript as Purescript
 import Ccap.Codegen.Scala as Scala
 import Ccap.Codegen.Shared (OutputSpec)
-import Data.Maybe (fromMaybe)
-import Data.String.Utils as String
 import Effect.Aff (Aff)
 import Node.Path (FilePath)
-import Test.Ccap.Codegen.Util (exceptAffT, findLine, print, runOrFail, sourceTmpl)
+import Test.Ccap.Codegen.Util (exceptAffT, matchKeyLine, runOrFail, sourceTmpl)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
@@ -27,23 +25,25 @@ specs =
       it "only uses exports.scalaPkg for file path"
         $ matchOutputPath Scala.outputSpec "test/ScalaExport.scala"
       it "uses the parent directory as the package"
-        $ matchKeyLine "package" Scala.outputSpec "package test"
+        $ matchKeyLine_ "package" Scala.outputSpec "package test"
       it "uses the last name as the main object name"
-        $ matchKeyLine "object" Scala.outputSpec "object ScalaExport {"
+        $ matchKeyLine_ "object" Scala.outputSpec "object ScalaExport {"
     describe "Purescript exports" do
       it "only uses exports.pursPkg for file path"
         $ matchOutputPath Purescript.outputSpec "Test/PurescriptExport.purs"
       it "uses the pursPkg for the module path"
-        $ matchKeyLine "module" Purescript.outputSpec "module Test.PurescriptExport where"
+        $ matchKeyLine_ "module" Purescript.outputSpec "module Test.PurescriptExport where"
     describe "Imports of custom Exports" do
       let
-        check = matchKeyLine_ importFile "ImportedType"
+        check = matchKeyLine importFile "ImportedType"
       describe "Scala imports" do
         it "References type with it's scala object name"
           $ check Scala.outputSpec "  type ImportedType = ScalaExport.ExportedType"
         it "Uses the imported module qualifier when defining record fields"
-          $ matchKeyLine_ importFile "field" Scala.outputSpec "  field: ScalaExport.ExportedType,"
-      describe "Scala imports" do
+          $ matchKeyLine importFile "field" Scala.outputSpec "  field: ScalaExport.ExportedType,"
+        it "Won't prefix if it's the imported file's class"
+          $ matchKeyLine importFile "ImportedRec" Scala.outputSpec "  type ImportedRec = ScalaExport"
+      describe "Purescript imports" do
         it "References with it's purescript module name"
           $ check Purescript.outputSpec "type ImportedType = PurescriptExport.ExportedType"
 
@@ -55,17 +55,5 @@ matchOutputPath outSpec outPath =
       path = outSpec.filePath source.contents
     pure $ path `shouldEqual` outPath
 
-matchKeyLine :: String -> OutputSpec -> String -> Aff Unit
-matchKeyLine = matchKeyLine_ tmplFile
-
-matchKeyLine_ :: FilePath -> String -> OutputSpec -> String -> Aff Unit
-matchKeyLine_ file keyWord outSpec line =
-  runOrFail do
-    source <- exceptAffT $ sourceTmpl file
-    let
-      printed = print outSpec source
-
-      keyLine =
-        findLine (String.includes keyWord) printed
-          # fromMaybe ("Keyword, " <> keyWord <> ", not found")
-    pure $ keyLine `shouldEqual` line
+matchKeyLine_ :: String -> OutputSpec -> String -> Aff Unit
+matchKeyLine_ = matchKeyLine tmplFile

--- a/test/Ccap/Codegen/Prefix.purs
+++ b/test/Ccap/Codegen/Prefix.purs
@@ -1,0 +1,41 @@
+module Test.Ccap.Codegen.Prefix
+  ( specs
+  ) where
+
+import Prelude
+import Ccap.Codegen.Scala as Scala
+import Effect.Aff (Aff)
+import Node.Path (FilePath)
+import Test.Ccap.Codegen.Util (matchKeyLine)
+import Test.Spec (Spec, describe, it)
+
+tmplFile :: FilePath
+tmplFile = "./test/resources/prefix/Prefix.tmpl"
+
+specs :: Spec Unit
+specs =
+  describe "Scala Prefixes" do
+    describe "External references" do
+      describe "To a class" do
+        describe "When they are the file's class" do
+          it "Are imported"
+            $ check "import external" "import external.Imported"
+          it "Are not prefixed since they are imported"
+            $ check "type ExternalClassRef" "  type ExternalClassRef = Imported"
+        it "Need prefixes if they aren't the file's class"
+          $ check "type ExternalRecRef" "  type ExternalRecRef = Imported.ImportedRec"
+      describe "Type references" do
+        it "Need prefixes"
+          $ check "type ExternalTypeRef" "  type ExternalTypeRef = Imported.ImportedType"
+    describe "Internal references" do
+      describe "To class definitions" do
+        it "Need prefixes if they are the file's class"
+          $ check "prefixInternalRef:" "  prefixInternalRef: Prefix.CustomType,"
+        it "Don't need prefixes if defined in the companion object"
+          $ check "customInternalRef:" "    customInternalRef: CustomType,"
+      describe "type references" do
+        it "Are defined in the companion object and don't need prefixes"
+          $ check "type InternalRef" "  type InternalRef = CustomType"
+
+check :: String -> String -> Aff Unit
+check keyword = matchKeyLine tmplFile keyword Scala.outputSpec

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,7 +1,6 @@
 module Test.Main where
 
 import Prelude
-
 import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Test.Ccap.Codegen.Annotations (specs) as Annotations
@@ -9,13 +8,17 @@ import Test.Ccap.Codegen.Exports (specs) as Exports
 import Test.Ccap.Codegen.FileSystem (specs) as FileSystem
 import Test.Ccap.Codegen.Imports (specs) as Imports
 import Test.Ccap.Codegen.Parser (specs) as Parser
+import Test.Ccap.Codegen.Prefix (specs) as Prefix
 import Test.Spec.Reporter.Console (consoleReporter)
 import Test.Spec.Runner (runSpec)
 
 main :: Effect Unit
-main = launchAff_ $ runSpec [ consoleReporter ] do
-  FileSystem.specs
-  Imports.specs
-  Parser.specs
-  Exports.specs
-  Annotations.specs
+main =
+  launchAff_
+    $ runSpec [ consoleReporter ] do
+        FileSystem.specs
+        Imports.specs
+        Parser.specs
+        Exports.specs
+        Annotations.specs
+        Prefix.specs

--- a/test/resources/exports/Exports.tmpl
+++ b/test/resources/exports/Exports.tmpl
@@ -2,3 +2,7 @@ scala: test.ScalaExport
 purs: Test.PurescriptExport
 
 type ExportedType: Int
+
+type ScalaExport: {
+  field: String
+}

--- a/test/resources/exports/Imports.tmpl
+++ b/test/resources/exports/Imports.tmpl
@@ -5,6 +5,8 @@ import Exports
 
 type ImportedType: Exports.ExportedType
 
+type ImportedRec: Exports.ScalaExport
+
 type Imports: {
   field: Exports.ExportedType
 }

--- a/test/resources/parser/Printed.purs_
+++ b/test/resources/parser/Printed.purs_
@@ -94,6 +94,11 @@ jsonCodec_Validated :: R.JsonCodec Validated
 jsonCodec_Validated =
   R.jsonCodec_string
 
+type ValidatedMaybe = Maybe (String)
+jsonCodec_ValidatedMaybe :: R.JsonCodec ValidatedMaybe
+jsonCodec_ValidatedMaybe =
+  (R.jsonCodec_maybe R.jsonCodec_string)
+
 type ValidatedRec =
   { name :: String
   }

--- a/test/resources/parser/Printed.scala
+++ b/test/resources/parser/Printed.scala
@@ -91,6 +91,12 @@ object Printed {
   def jsonDecoderValidated[M[_]: Monad]: Decoder.Field[M, Validated] =
     Decoder.string.maxLength(5)
 
+  type ValidatedMaybe = Option[String]
+  lazy val jsonEncoderValidatedMaybe: Encoder[ValidatedMaybe, argonaut.Json] =
+    Encoder.string.option
+  def jsonDecoderValidatedMaybe[M[_]: Monad]: Decoder.Field[M, ValidatedMaybe] =
+    Decoder.string.maxLength(5).option
+
   final case class ValidatedRec(
     name: String,
   )
@@ -99,7 +105,7 @@ object Printed {
       "name" -> Encoder.string.encode(x.name),
     )
   def jsonDecoderValidatedRec[M[_]: Monad]: Decoder.Form[M, ValidatedRec] =
-    Decoder.string.property("name").maxLength(5).map(ValidatedRec.apply)
+    Decoder.string.maxLength(5).property("name").map(ValidatedRec.apply)
   object ValidatedRec {
     object FieldNames {
       val Name: String = "name"

--- a/test/resources/parser/Printed.tmpl
+++ b/test/resources/parser/Printed.tmpl
@@ -16,6 +16,8 @@ type InternalRef: Integer
 type ExternalRef: Imported.ImportedType
 type Validated: String
   <validations maxLength="5">
+type ValidatedMaybe: Maybe String
+  <validations maxLength="5">
 type ValidatedRec: {
   name: String
     <validations maxLength="5">

--- a/test/resources/prefix/Imported.tmpl
+++ b/test/resources/prefix/Imported.tmpl
@@ -1,0 +1,12 @@
+scala: external.Imported
+purs: External.Imported
+
+type ImportedType: String
+
+type ImportedRec: {
+  unused: Boolean
+}
+
+type Imported: {
+  unused: Boolean
+}

--- a/test/resources/prefix/Prefix.tmpl
+++ b/test/resources/prefix/Prefix.tmpl
@@ -1,0 +1,22 @@
+scala: test.Prefix
+purs: Test.Prefix
+
+import Imported
+
+type CustomType: String
+
+type InternalRef: CustomType
+
+type ExternalTypeRef: Imported.ImportedType
+
+type ExternalRecRef: Imported.ImportedRec
+
+type ExternalClassRef: Imported.Imported
+
+type CustomRec: {
+  customInternalRef: CustomType
+}
+
+type Prefix: {
+  prefixInternalRef: CustomType
+}


### PR DESCRIPTION
* Validations were done after all type definitions:
  - Before: `Decoder.string.option.maxLength(5)`
  - After: `Decoder.string.maxLength(5).option`
  - This opens syntax questions about how to add multiple validations to
    different types in the same type declaration.  If I have an array of
    strings how do I declare a validation on the strings and another on the
    array?
* Scala internal type references were fixed by wildcard importing the companion
  object.
  - This isn't safe for any scala file but should be safe for any that we generate.
  - It could be avoided by passing the `TypeDeclOutputMode` all the way to
    `typeRef` but I'd rather rewrite the scala printer.