### PR TITLE
Fix a bug with relative imports

### DIFF
--- a/src/Ccap/Codegen/Imports.purs
+++ b/src/Ccap/Codegen/Imports.purs
@@ -7,6 +7,7 @@ module Ccap.Codegen.Imports
   , importsInScope
   , importsInScopes
   , parseImports
+  , possibleImportPaths
   , resolveImport
   , validateImports
   ) where

--- a/src/Ccap/Codegen/Imports.purs
+++ b/src/Ccap/Codegen/Imports.purs
@@ -45,9 +45,15 @@ data ImportError
 instance importValidationError :: ValidationError ImportError where
   printError = case _ of
     NotFound mod imprt ->
-      mod.name <> " tried to import module: " <> imprt
+      mod.name
+        <> " tried to import module: "
+        <> imprt
         <> " but it does not exist, or was not included."
-    ParseError imprt message -> "Parsing imported module, " <> imprt <> ", failed with error: " <> message
+    ParseError imprt message ->
+      "Parsing imported module, "
+        <> imprt
+        <> ", failed with error: "
+        <> message
 
 importPath :: Import -> FilePath
 importPath = String.replaceAll (Pattern ".") (Replacement Path.sep)

--- a/src/Ccap/Codegen/Imports.purs
+++ b/src/Ccap/Codegen/Imports.purs
@@ -3,9 +3,11 @@ module Ccap.Codegen.Imports
   , Imported
   , Includes
   , importInScope
+  , importPath
   , importsInScope
   , importsInScopes
   , parseImports
+  , resolveImport
   , validateImports
   ) where
 
@@ -32,7 +34,7 @@ type FoundImport
   = { imprt :: Import, filePath :: FilePath }
 
 type Imported
-  = { imprt :: Import, mod :: Module }
+  = Source { imprt :: Import, mod :: Module }
 
 data ImportError
   = NotFound Module Import
@@ -46,14 +48,16 @@ instance importValidationError :: ValidationError ImportError where
         <> " but it does not exist, or was not included."
     ParseError imprt message -> "Parsing imported module, " <> imprt <> ", failed with error: " <> message
 
+importPath :: Import -> FilePath
+importPath = String.replaceAll (Pattern ".") (Replacement Path.sep)
+
+resolveImport :: FilePath -> Import -> FilePath
+resolveImport filePath = FS.joinPaths filePath <<< flip append ".tmpl" <<< importPath
+
 possibleImportPaths :: Includes -> FilePath -> Import -> Array FilePath
 possibleImportPaths includes source imprt =
-  let
-    sourceDirs = Path.dirname source : includes
-
-    importPath = String.replaceAll (Pattern ".") (Replacement Path.sep) imprt
-  in
-    sourceDirs <#> flip FS.joinPaths importPath <#> flip append ".tmpl"
+  (Path.dirname source : includes)
+    <#> (flip resolveImport $ importPath imprt)
 
 importInScope :: Includes -> Source Module -> Import -> Effect (Either ImportError FoundImport)
 importInScope included { source, contents } imprt =
@@ -90,7 +94,10 @@ importsInScopes includes sources =
 parseImports :: Array FoundImport -> Effect (Either (Array ImportError) (Array Imported))
 parseImports imports = traverse parse imports <#> toValidation
   where
-  parse { imprt, filePath } = bimap (ParseError imprt) (\source -> { imprt, mod: source.contents }) <$> FS.sourceFile filePath
+  parse { imprt, filePath } =
+    bimap (ParseError imprt)
+      (\source -> { source: filePath, contents: { imprt, mod: source.contents } })
+      <$> FS.sourceFile filePath
 
 -- | Validate that the imports of the given modules exist and parse the imported modules
 -- | Note: Does not validate the contents of the imported files.

--- a/test/Ccap/Codegen/Imports.purs
+++ b/test/Ccap/Codegen/Imports.purs
@@ -91,8 +91,8 @@ specs =
                 withPrintErrors $ ExceptT $ validateImports includes [ source ]
         shouldBeRight imports
 
-    itCanValidateAllImports filePaths includes =
-      it "Can validate imports for multiple modules" do
+    itCanValidateAllModules filePaths includes =
+      it "Can validate all modules" do
         modules <-
           liftEffect
             $ runExceptT do
@@ -138,6 +138,7 @@ specs =
         itCanFindImports submoduleSource []
         itCanValidateImports submoduleSource []
         itHasValidTypeReferences submoduleSource []
+        itCanValidateAllModules [ submoduleSource ] []
       describe "a file with an external reference" do
         itCanBeParsed externalSource
         itHasImports externalSource [ "External" ]
@@ -145,6 +146,7 @@ specs =
         itCanValidateImports externalSource [ external_ ]
         itFailsWithoutIncludes externalSource
         itHasValidTypeReferences externalSource [ external_ ]
+        itCanValidateAllModules [ externalSource ] [ external_ ]
       describe "a file with an external reference to a submodule" do
         itCanBeParsed externalSubmoduleSource
         itHasImports externalSubmoduleSource [ "submodule.ExternalSubmodule" ]
@@ -152,5 +154,6 @@ specs =
         itCanValidateImports externalSubmoduleSource [ external_ ]
         itFailsWithoutIncludes externalSubmoduleSource
         itHasValidTypeReferences externalSubmoduleSource [ external_ ]
-      describe "two files with identical relative imports" do
-        itCanValidateAllImports [ app1, app2 ] []
+        itCanValidateAllModules [ externalSubmoduleSource ] [ external_ ]
+      describe "two files with identical relative imports"
+        $ itCanValidateAllModules [ app1, app2 ] []

--- a/test/resources/imports/app1/Main.tmpl
+++ b/test/resources/imports/app1/Main.tmpl
@@ -1,0 +1,6 @@
+scala: test.App1
+purs: Test.App1
+
+import Types
+
+type App: Types.Foo

--- a/test/resources/imports/app1/Types.tmpl
+++ b/test/resources/imports/app1/Types.tmpl
@@ -1,0 +1,4 @@
+scala: test.Lib1
+purs: Test.Lib1
+
+type Foo: Int

--- a/test/resources/imports/app2/Main.tmpl
+++ b/test/resources/imports/app2/Main.tmpl
@@ -1,0 +1,6 @@
+scala: test.App2
+purs: Test.App2
+
+import Types
+
+type App: Types.Bar

--- a/test/resources/imports/app2/Types.tmpl
+++ b/test/resources/imports/app2/Types.tmpl
@@ -1,0 +1,4 @@
+scala: test.Lib2
+purs: Test.Lib2
+
+type Bar: Int


### PR DESCRIPTION
If two files have identical import statements but refer to different files,
then the second file might fail to validate since it would use the first files
import.