### PR TITLE
Allow templates with only sum types

### DIFF
--- a/src/Ccap/Codegen/Purescript.purs
+++ b/src/Ccap/Codegen/Purescript.purs
@@ -189,7 +189,7 @@ sumJsonCodec name vs = do
     decode =
       text "decode: case _ of"
         // indented (branches decodeBranch // fallthrough)
-  pure $ text "R.composeCodec"
+  emitRuntime $ text "R.composeCodec"
     // indented (delimitedLiteral Vert '{' '}' [ decode, encode ] // text "R.jsonCodec_string")
   where
   branches branch = vcat Boxes.left (vs <#> branch)


### PR DESCRIPTION
Templates defining only sum types would not compile in purescript since they
weren't importing Runtime.