### PR TITLE
Allow custom encoders/decoders to deconstruct JSON directly

### DIFF
--- a/src/Ccap/Codegen/PrettyPrint.purs
+++ b/src/Ccap/Codegen/PrettyPrint.purs
@@ -40,6 +40,7 @@ primitive p =
     PDecimal -> "Decimal"
     PString -> "String"
     PStringValidationHack -> "StringValidationHack"
+    PJson -> "Json"
 
 indented :: Box -> Box
 indented b = emptyBox 0 2 <<>> b

--- a/src/Ccap/Codegen/Purescript.purs
+++ b/src/Ccap/Codegen/Purescript.purs
@@ -105,6 +105,7 @@ primitive = case _ of
   PDecimal -> emit { mod: "Data.Decimal", typ: Just "Decimal", alias: Nothing } (text "Decimal")
   PString -> pure (text "String")
   PStringValidationHack -> pure (text "String")
+  PJson -> emit { mod: "Data.Argonaut.Core", typ: Nothing, alias: Just "A" } (text "A.Json")
 
 type Extern
   = { prefix :: String, t :: String }
@@ -294,6 +295,7 @@ jsonCodec ty = case ty of
                   PDecimal -> "decimal"
                   PString -> "string"
                   PStringValidationHack -> "string"
+                  PJson -> "json"
               )
       )
   Array t -> tycon "array" t

--- a/src/Ccap/Codegen/Runtime.purs
+++ b/src/Ccap/Codegen/Runtime.purs
@@ -23,6 +23,12 @@ type Codec a b
 type JsonCodec a
   = Codec Json a
 
+jsonCodec_json :: JsonCodec Json
+jsonCodec_json =
+  { decode: Right
+  , encode: identity
+  }
+
 jsonCodec_string :: JsonCodec String
 jsonCodec_string =
   { decode: maybe (Left "This value must be a string") Right <<< Argonaut.toString

--- a/src/Ccap/Codegen/Scala.purs
+++ b/src/Ccap/Codegen/Scala.purs
@@ -272,6 +272,7 @@ primitive =
         PDecimal -> "BigDecimal"
         PString -> "String"
         PStringValidationHack -> "String"
+        PJson -> "argonaut.Json"
 
 generic :: String -> Box -> Box
 generic typeName param = text typeName <<>> char '[' <<>> param <<>> char ']'
@@ -387,6 +388,7 @@ jsonPrimitive = case _ of
   PDecimal -> ".decimal"
   PString -> ".string"
   PStringValidationHack -> ".stringValidationHack"
+  PJson -> ".json"
 
 decoderValidations :: Annotations -> Box
 decoderValidations annots = foldl (<<>>) nullBox validations

--- a/src/Ccap/Codegen/Types.purs
+++ b/src/Ccap/Codegen/Types.purs
@@ -109,6 +109,7 @@ data Primitive
   | PDecimal
   | PString
   | PStringValidationHack
+  | PJson
 
 -- Instances here to avoid cluttering the above
 derive instance eqType :: Eq Type


### PR DESCRIPTION
This commit adds JSON as an additional primitive type. In order to
maintain a modicum of safety, it is only available in wrapped types.

It should only be used with custom encoders/decoders although this is
not currently enforced.

Story: S-23059