### PR TITLE
Reorganize Doobie related Scala generation

### DIFF
--- a/src/Ccap/Codegen/Ast.purs
+++ b/src/Ccap/Codegen/Ast.purs
@@ -3,6 +3,7 @@ module Ccap.Codegen.Ast
   , Module(..)
   , RecordProp(..)
   , ScalaDecoderType(..)
+  , SqlType(..)
   , TRef
   , TopType(..)
   , Typ(..)
@@ -16,6 +17,7 @@ module Ccap.Codegen.Ast
 
 import Prelude
 import Ccap.Codegen.Cst as Cst
+import Ccap.Codegen.DbSupportType (DbSupportType)
 import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..))
@@ -68,6 +70,14 @@ type RecordProp
   = { name :: String
     , typ :: TypeOrParam
     , annots :: Array Cst.Annotation
+    , sqlType :: Maybe SqlType
+    }
+
+data SqlType
+  = SqlTypePrimitive String
+  | SqlTypeDbSupportType
+    { needsImports :: Boolean
+    , dbSupportType :: DbSupportType
     }
 
 data Constructor
@@ -147,4 +157,11 @@ derive instance eqTypeDecl :: Eq TypeDecl
 derive instance genericTypeDecl :: Generic TypeDecl _
 
 instance showTypeDecl :: Show TypeDecl where
+  show = genericShow
+
+derive instance eqSqlType :: Eq SqlType
+
+derive instance genericSqlType :: Generic SqlType _
+
+instance showSqlType :: Show SqlType where
   show = genericShow

--- a/src/Ccap/Codegen/Database.purs
+++ b/src/Ccap/Codegen/Database.purs
@@ -5,7 +5,7 @@ module Ccap.Codegen.Database
 
 import Prelude
 import Ccap.Codegen.Cst as Cst
-import Ccap.Codegen.Shared (dbSupportTypes)
+import Ccap.Codegen.DbSupportType (dbSupportTypes)
 import Control.Monad.Except (ExceptT, except, withExceptT, runExceptT)
 import Data.Array as Array
 import Data.Array.NonEmpty (NonEmptyArray)

--- a/src/Ccap/Codegen/DbSupportType.purs
+++ b/src/Ccap/Codegen/DbSupportType.purs
@@ -1,0 +1,84 @@
+module Ccap.Codegen.DbSupportType
+  ( DbSupportType
+  , dbSupportTypes
+  , SupportType
+  , supportTypes
+  ) where
+
+type SupportType
+  = { moduleName :: String
+    , typeName :: String
+    , underlyingSqlType :: String
+    }
+
+supportTypes :: Array SupportType
+supportTypes =
+  [ { moduleName: "CaseNoSupport"
+    , typeName: "CaseNo"
+    , underlyingSqlType: "text"
+    }
+  , { moduleName: "OccSupport"
+    , typeName: "OccId"
+    , underlyingSqlType: "text"
+    }
+  ]
+
+type DbSupportType
+  = { dataType :: String
+    , instances ::
+        { equal :: String
+        , meta :: String
+        }
+    , moduleName :: String
+    , typeName :: String
+    , underlyingSqlType :: String
+    }
+
+dbSupportTypes :: Array DbSupportType
+dbSupportTypes =
+  [ { dataType: "date"
+    , instances:
+        { equal: "gov.wicourts.common.instances.dates.localDateEqual"
+        , meta: "gov.wicourts.common.Meta.metaLocalDate"
+        }
+    , moduleName: "DateTimeSupport"
+    , typeName: "Date"
+    , underlyingSqlType: "date"
+    }
+  , { dataType: "interval"
+    , instances:
+        { equal: "gov.wicourts.jsoncommon.data.DurationWithLife.Duration.eqDuration"
+        , meta: "gov.wicourts.jsoncommon.data.DurationWithLife.Duration.metaDuration"
+        }
+    , moduleName: "DateTimeSupport"
+    , typeName: "Duration"
+    , underlyingSqlType: "interval"
+    }
+  , { dataType: "time without time zone"
+    , instances:
+        { equal: "gov.wicourts.common.instances.times.equalLocalTime"
+        , meta: "gov.wicourts.common.Meta.metaLocalTime"
+        }
+    , moduleName: "DateTimeSupport"
+    , typeName: "Time"
+    , underlyingSqlType: "time"
+    }
+  , { dataType: "timestamp with time zone"
+    , instances:
+        { equal: "gov.wicourts.common.instances.dates.localDateTimeEqual"
+        , meta: "gov.wicourts.common.Meta.metaLocalDateTime"
+        }
+    , moduleName: "DateTimeSupport"
+    , typeName: "Timestamp"
+    , underlyingSqlType: "timestamp"
+    }
+  , { dataType: "uuid"
+    , instances:
+        { equal: "gov.wicourts.common.instances.uuid.equalUUID"
+        , meta: "gov.wicourts.common.Meta.metaUuid"
+        }
+    , moduleName: "UUIDSupport"
+    , typeName: "UUID"
+    , underlyingSqlType: "uuid"
+    }
+  ]

--- a/src/Ccap/Codegen/Error.purs
+++ b/src/Ccap/Codegen/Error.purs
@@ -33,6 +33,7 @@ data Import
 data TypeDecl
   = DuplicateType
   | DuplicateRecordProperty Cst.RecordProp
+  | CannotResolveSqlType Cst.RecordProp
   | DuplicateConstructorNames (Array Cst.ConstructorName)
   | UnknownTypeParam Cst.TypeParam
   | CircularType (Array String)
@@ -66,6 +67,10 @@ toString = case _ of
           TypeDecl typeDeclError decl -> case typeDeclError of
             DuplicateType -> "type " <> Cst.typeDeclName decl <> " is defined multiple times"
             DuplicateRecordProperty { name } -> "record property " <> name <> " is defined multiple times"
+            CannotResolveSqlType { name } ->
+              "record property "
+                <> name
+                <> " cannot be mapped to a SQL type. Only primitive, date-like, OCC ID, and UUID types (wrapped/unwrapped) are supported."
             DuplicateConstructorNames names -> "constructor " <> String.joinWith ", " (map (\(Cst.ConstructorName name) -> name) names) <> " is defined multiple times"
             UnknownTypeParam (Cst.TypeParam param) -> "Unknown type parameter " <> param
             CircularType names ->

--- a/src/Ccap/Codegen/Shared.purs
+++ b/src/Ccap/Codegen/Shared.purs
@@ -1,9 +1,7 @@
 module Ccap.Codegen.Shared
-  ( DbSupportType
-  , DelimitedLiteralDir(..)
+  ( DelimitedLiteralDir(..)
   , FastPathDecoderType(..)
   , OutputSpec
-  , dbSupportTypes
   , delimitedLiteral
   , fastPathDecoderType
   , indented
@@ -18,72 +16,6 @@ import Data.Maybe (Maybe(..), isNothing)
 import Data.Tuple (Tuple(..))
 import Text.PrettyPrint.Boxes (Box, char, emptyBox, hcat, vcat, (<<+>>), (<<>>))
 import Text.PrettyPrint.Boxes (left, top) as Boxes
-
-type DbSupportType
-  = { dataType :: String
-    , instances ::
-        { equal :: String
-        , meta :: String
-        }
-    , isCommon :: Boolean
-    , moduleName :: String
-    , typeName :: String
-    , underlyingSqlType :: String
-    }
-
-dbSupportTypes :: Array DbSupportType
-dbSupportTypes =
-  [ { dataType: "date"
-    , instances:
-        { equal: "gov.wicourts.common.instances.dates.localDateEqual"
-        , meta: "gov.wicourts.common.Meta.metaLocalDate"
-        }
-    , isCommon: true
-    , moduleName: "DateTimeSupport"
-    , typeName: "Date"
-    , underlyingSqlType: "date"
-    }
-  , { dataType: "interval"
-    , instances:
-        { equal: "gov.wicourts.jsoncommon.data.DurationWithLife.Duration.eqDuration"
-        , meta: "gov.wicourts.jsoncommon.data.DurationWithLife.Duration.metaDuration"
-        }
-    , isCommon: false
-    , moduleName: "DateTimeSupport"
-    , typeName: "Duration"
-    , underlyingSqlType: "interval"
-    }
-  , { dataType: "time without time zone"
-    , instances:
-        { equal: "gov.wicourts.common.instances.times.equalLocalTime"
-        , meta: "gov.wicourts.common.Meta.metaLocalTime"
-        }
-    , isCommon: true
-    , moduleName: "DateTimeSupport"
-    , typeName: "Time"
-    , underlyingSqlType: "time"
-    }
-  , { dataType: "timestamp with time zone"
-    , instances:
-        { equal: "gov.wicourts.common.instances.dates.localDateTimeEqual"
-        , meta: "gov.wicourts.common.Meta.metaLocalDateTime"
-        }
-    , isCommon: true
-    , moduleName: "DateTimeSupport"
-    , typeName: "Timestamp"
-    , underlyingSqlType: "timestamp"
-    }
-  , { dataType: "uuid"
-    , instances:
-        { equal: "gov.wicourts.common.instances.uuid.equalUUID"
-        , meta: "gov.wicourts.common.Meta.metaUuid"
-        }
-    , isCommon: true
-    , moduleName: "UUIDSupport"
-    , typeName: "UUID"
-    , underlyingSqlType: "uuid"
-    }
-  ]
 
 type OutputSpec
   = { render :: Ast.Module -> Maybe String

--- a/test/resources/parser/Printed.scala
+++ b/test/resources/parser/Printed.scala
@@ -8,72 +8,56 @@ import gov.wicourts.jsoncommon.Encoder
 
 object Printed {
   type YesNo = Boolean
-  def jsonEncoderYesNo: Encoder[YesNo, argonaut.Json] = {
+  def jsonEncoderYesNo: Encoder[YesNo, argonaut.Json] =
     Encoder.boolean
-  }
-  def jsonDecoderYesNo[M[_]: Monad]: Decoder.Field[M, YesNo] = {
+  def jsonDecoderYesNo[M[_]: Monad]: Decoder.Field[M, YesNo] =
     Decoder.boolean[M]
-  }
   type Number = BigDecimal
-  def jsonEncoderNumber: Encoder[Number, argonaut.Json] = {
+  def jsonEncoderNumber: Encoder[Number, argonaut.Json] =
     Encoder.decimal
-  }
-  def jsonDecoderNumber[M[_]: Monad]: Decoder.Field[M, Number] = {
+  def jsonDecoderNumber[M[_]: Monad]: Decoder.Field[M, Number] =
     Decoder.decimal[M]
-  }
   type Text = String
-  def jsonEncoderText: Encoder[Text, argonaut.Json] = {
+  def jsonEncoderText: Encoder[Text, argonaut.Json] =
     Encoder.string
-  }
-  def jsonDecoderText[M[_]: Monad]: Decoder.Field[M, Text] = {
+  def jsonDecoderText[M[_]: Monad]: Decoder.Field[M, Text] =
     Decoder.string[M]
-  }
   type Integer = Int
-  def jsonEncoderInteger: Encoder[Integer, argonaut.Json] = {
+  def jsonEncoderInteger: Encoder[Integer, argonaut.Json] =
     Encoder.int
-  }
-  def jsonDecoderInteger[M[_]: Monad]: Decoder.Field[M, Integer] = {
+  def jsonDecoderInteger[M[_]: Monad]: Decoder.Field[M, Integer] =
     Decoder.int[M]
-  }
   final abstract class TagTypeT
   type TagType = gov.wicourts.common.@@[Int, TagTypeT]
   val TagType: gov.wicourts.common.Tag.TagOf[TagTypeT] = gov.wicourts.common.Tag.of[TagTypeT]
-  def jsonEncoderTagType: Encoder[TagType, argonaut.Json] = {
+  def jsonEncoderTagType: Encoder[TagType, argonaut.Json] =
     Encoder.int.tagged
-  }
-  def jsonDecoderTagType[M[_]: Monad]: Decoder.Field[M, TagType] = {
+  def jsonDecoderTagType[M[_]: Monad]: Decoder.Field[M, TagType] =
     Decoder.int[M].tagged
-  }
   type Optional = Option[Int]
-  def jsonEncoderOptional: Encoder[Optional, argonaut.Json] = {
+  def jsonEncoderOptional: Encoder[Optional, argonaut.Json] =
     Encoder.int.option
-  }
-  def jsonDecoderOptional[M[_]: Monad]: Decoder.Field[M, Optional] = {
+  def jsonDecoderOptional[M[_]: Monad]: Decoder.Field[M, Optional] =
     Decoder.int[M].option
-  }
   type Collection = List[Int]
-  def jsonEncoderCollection: Encoder[Collection, argonaut.Json] = {
+  def jsonEncoderCollection: Encoder[Collection, argonaut.Json] =
     Encoder.int.list
-  }
-  def jsonDecoderCollection[M[_]: Monad]: Decoder.Field[M, Collection] = {
+  def jsonDecoderCollection[M[_]: Monad]: Decoder.Field[M, Collection] =
     Decoder.int[M].list
-  }
   final case class Point(
     x: Int,
     y: Int,
   )
-  def jsonEncoderPoint: Encoder[Point, argonaut.Json] = {
+  def jsonEncoderPoint: Encoder[Point, argonaut.Json] =
     x => argonaut.Json.obj(
       "x" -> Encoder.int.encode(x.x),
       "y" -> Encoder.int.encode(x.y),
     )
-  }
-  def jsonDecoderPoint[M[_]: Monad]: Decoder.Form[M, Point] = {
-    cats.Apply[Decoder.Form[M, *]].map2(
+  def jsonDecoderPoint[M[_]: Monad]: Decoder.Form[M, Point] =
+    Decoder.formApplicative[M].map2(
       Decoder.int[M].property("x"),
       Decoder.int[M].property("y"),
     )(Point.apply)
-  }
   object Point {
     object FieldNames {
       val X: String = "x"
@@ -81,62 +65,49 @@ object Printed {
     }
   }
   type InternalRef = Integer
-  def jsonEncoderInternalRef: Encoder[InternalRef, argonaut.Json] = {
+  def jsonEncoderInternalRef: Encoder[InternalRef, argonaut.Json] =
     jsonEncoderInteger
-  }
-  def jsonDecoderInternalRef[M[_]: Monad]: Decoder.Field[M, InternalRef] = {
+  def jsonDecoderInternalRef[M[_]: Monad]: Decoder.Field[M, InternalRef] =
     jsonDecoderInteger[M]
-  }
   type ExternalRef = Imported.ImportedType
-  def jsonEncoderExternalRef: Encoder[ExternalRef, argonaut.Json] = {
+  def jsonEncoderExternalRef: Encoder[ExternalRef, argonaut.Json] =
     Imported.jsonEncoderImportedType
-  }
-  def jsonDecoderExternalRef[M[_]: Monad]: Decoder.Field[M, ExternalRef] = {
+  def jsonDecoderExternalRef[M[_]: Monad]: Decoder.Field[M, ExternalRef] =
     Imported.jsonDecoderImportedType[M]
-  }
   type Validated = String
-  def jsonEncoderValidated: Encoder[Validated, argonaut.Json] = {
+  def jsonEncoderValidated: Encoder[Validated, argonaut.Json] =
     Encoder.string
-  }
-  def jsonDecoderValidated[M[_]: Monad]: Decoder.Field[M, Validated] = {
+  def jsonDecoderValidated[M[_]: Monad]: Decoder.Field[M, Validated] =
     Decoder.string[M].maxLength(5)
-  }
   type ValidatedMaybe = Option[String]
-  def jsonEncoderValidatedMaybe: Encoder[ValidatedMaybe, argonaut.Json] = {
+  def jsonEncoderValidatedMaybe: Encoder[ValidatedMaybe, argonaut.Json] =
     Encoder.string.option
-  }
-  def jsonDecoderValidatedMaybe[M[_]: Monad]: Decoder.Field[M, ValidatedMaybe] = {
+  def jsonDecoderValidatedMaybe[M[_]: Monad]: Decoder.Field[M, ValidatedMaybe] =
     Decoder.string[M].maxLength(5).option
-  }
   final case class ValidatedRec(
     name: String,
   )
-  def jsonEncoderValidatedRec: Encoder[ValidatedRec, argonaut.Json] = {
+  def jsonEncoderValidatedRec: Encoder[ValidatedRec, argonaut.Json] =
     x => argonaut.Json.obj(
       "name" -> Encoder.string.encode(x.name),
     )
-  }
-  def jsonDecoderValidatedRec[M[_]: Monad]: Decoder.Form[M, ValidatedRec] = {
+  def jsonDecoderValidatedRec[M[_]: Monad]: Decoder.Form[M, ValidatedRec] =
     Decoder.string[M].maxLength(5).property("name").map(ValidatedRec.apply)
-  }
   object ValidatedRec {
     object FieldNames {
       val Name: String = "name"
     }
   }
   type ArrayOfArrayOfArrayString = List[List[List[String]]]
-  def jsonEncoderArrayOfArrayOfArrayString: Encoder[ArrayOfArrayOfArrayString, argonaut.Json] = {
+  def jsonEncoderArrayOfArrayOfArrayString: Encoder[ArrayOfArrayOfArrayString, argonaut.Json] =
     Encoder.string.list.list.list
-  }
-  def jsonDecoderArrayOfArrayOfArrayString[M[_]: Monad]: Decoder.Field[M, ArrayOfArrayOfArrayString] = {
+  def jsonDecoderArrayOfArrayOfArrayString[M[_]: Monad]: Decoder.Field[M, ArrayOfArrayOfArrayString] =
     Decoder.string[M].list.list.list
-  }
   type ArrayOfSomething[A] = List[A]
   def jsonEncoderArrayOfSomething[A](
     jsonEncoder_param_A: Encoder[A, argonaut.Json],
-  ): Encoder[ArrayOfSomething[A], argonaut.Json] = {
+  ): Encoder[ArrayOfSomething[A], argonaut.Json] =
     jsonEncoder_param_A.list
-  }
   // Scala decoders that involve parameterized types are not supported
   sealed trait Either[A, B]
   object Either {
@@ -150,7 +121,7 @@ object Printed {
   def jsonEncoderEither[A, B](
     jsonEncoder_param_A: Encoder[A, argonaut.Json],
     jsonEncoder_param_B: Encoder[B, argonaut.Json],
-  ): Encoder[Either[A, B], argonaut.Json] = {
+  ): Encoder[Either[A, B], argonaut.Json] =
     _ match {
       case Either.Left(
         param_0,
@@ -171,14 +142,12 @@ object Printed {
           ),
         )
     }
-  }
   // Scala decoders that involve parameterized types are not supported
   type EitherWithStringError[A] = Either[String, A]
   def jsonEncoderEitherWithStringError[A](
     jsonEncoder_param_A: Encoder[A, argonaut.Json],
-  ): Encoder[EitherWithStringError[A], argonaut.Json] = {
+  ): Encoder[EitherWithStringError[A], argonaut.Json] =
     jsonEncoderEither(Encoder.string, jsonEncoder_param_A)
-  }
   // Scala decoders that involve parameterized types are not supported
   sealed trait List[A]
   object List {
@@ -190,7 +159,7 @@ object Printed {
   }
   def jsonEncoderList[A](
     jsonEncoder_param_A: Encoder[A, argonaut.Json],
-  ): Encoder[List[A], argonaut.Json] = {
+  ): Encoder[List[A], argonaut.Json] =
     _ match {
       case List.Nil() =>
         Encoder.constructor(
@@ -209,7 +178,6 @@ object Printed {
           ),
         )
     }
-  }
   // Scala decoders that involve parameterized types are not supported
   final case class Tuple[A, B](
     param_0: A,
@@ -218,7 +186,7 @@ object Printed {
   def jsonEncoderTuple[A, B](
     jsonEncoder_param_A: Encoder[A, argonaut.Json],
     jsonEncoder_param_B: Encoder[B, argonaut.Json],
-  ): Encoder[Tuple[A, B], argonaut.Json] = {
+  ): Encoder[Tuple[A, B], argonaut.Json] =
     _ match {
       case Tuple(
         param_0,
@@ -232,14 +200,12 @@ object Printed {
           ),
         )
     }
-  }
   // Scala decoders that involve parameterized types are not supported
   type NonEmptyList[A] = Tuple[A, List[A]]
   def jsonEncoderNonEmptyList[A](
     jsonEncoder_param_A: Encoder[A, argonaut.Json],
-  ): Encoder[NonEmptyList[A], argonaut.Json] = {
+  ): Encoder[NonEmptyList[A], argonaut.Json] =
     jsonEncoderTuple(jsonEncoder_param_A, jsonEncoderList(jsonEncoder_param_A))
-  }
   // Scala decoders that involve parameterized types are not supported
   final case class AnotherNonEmptyList[A](
     head: A,
@@ -247,12 +213,11 @@ object Printed {
   )
   def jsonEncoderAnotherNonEmptyList[A](
     jsonEncoder_param_A: Encoder[A, argonaut.Json],
-  ): Encoder[AnotherNonEmptyList[A], argonaut.Json] = {
+  ): Encoder[AnotherNonEmptyList[A], argonaut.Json] =
     x => argonaut.Json.obj(
       "head" -> jsonEncoder_param_A.encode(x.head),
       "tail" -> jsonEncoderList(jsonEncoder_param_A).encode(x.tail),
     )
-  }
   // Scala decoders that involve parameterized types are not supported
   object AnotherNonEmptyList {
     object FieldNames {
@@ -263,9 +228,8 @@ object Printed {
   type NonEmptyArray[A] = Tuple[A, List[A]]
   def jsonEncoderNonEmptyArray[A](
     jsonEncoder_param_A: Encoder[A, argonaut.Json],
-  ): Encoder[NonEmptyArray[A], argonaut.Json] = {
+  ): Encoder[NonEmptyArray[A], argonaut.Json] =
     jsonEncoderTuple(jsonEncoder_param_A, jsonEncoder_param_A.list)
-  }
   // Scala decoders that involve parameterized types are not supported
   sealed trait Enum {
     def tag: String
@@ -281,12 +245,11 @@ object Printed {
       override def tag: String = "Blue"
     }
   }
-  def jsonEncoderEnum: Encoder[Enum, argonaut.Json] = {
+  def jsonEncoderEnum: Encoder[Enum, argonaut.Json] =
     Encoder.string.compose(
       _.tag
     )
-  }
-  def jsonDecoderEnum[M[_]: Monad]: Decoder.Field[M, Enum] = {
+  def jsonDecoderEnum[M[_]: Monad]: Decoder.Field[M, Enum] =
     Decoder.string[M].toEither.andThen(
       Decoder.enum[M, Enum](
         "Enum",
@@ -297,26 +260,23 @@ object Printed {
       .toEither
     )
     .toValidated
-  }
   final case class RecordOfStrings(
     a: List[String],
     b: List[String],
     c: List[String],
   )
-  def jsonEncoderRecordOfStrings: Encoder[RecordOfStrings, argonaut.Json] = {
+  def jsonEncoderRecordOfStrings: Encoder[RecordOfStrings, argonaut.Json] =
     x => argonaut.Json.obj(
       "a" -> jsonEncoderList(Encoder.string).encode(x.a),
       "b" -> jsonEncoderList(Encoder.string).encode(x.b),
       "c" -> jsonEncoderList(Encoder.string).encode(x.c),
     )
-  }
-  def jsonDecoderRecordOfStrings[M[_]: Monad]: Decoder.Form[M, RecordOfStrings] = {
-    cats.Apply[Decoder.Form[M, *]].map3(
+  def jsonDecoderRecordOfStrings[M[_]: Monad]: Decoder.Form[M, RecordOfStrings] =
+    Decoder.formApplicative[M].map3(
       jsonDecoderList[M].property("a"),
       jsonDecoderList[M].property("b"),
       jsonDecoderList[M].property("c"),
     )(RecordOfStrings.apply)
-  }
   object RecordOfStrings {
     object FieldNames {
       val A: String = "a"
@@ -328,10 +288,9 @@ object Printed {
   def jsonEncoderNativeEither[A, B](
     jsonEncoder_param_A: Encoder[A, argonaut.Json],
     jsonEncoder_param_B: Encoder[B, argonaut.Json],
-  ): Encoder[NativeEither[A, B], argonaut.Json] = {
+  ): Encoder[NativeEither[A, B], argonaut.Json] =
     jsonEncoderEither(jsonEncoder_param_A, jsonEncoder_param_B).compose(
       Encoder.either
     )
-  }
   // Scala decoders that involve parameterized types are not supported
 }


### PR DESCRIPTION
  - Move column definitions to separate Columns object
  - Make PrimaryKey a case class
  - Lookup and validate SQL related information when constructing AST, report errors robustly
  - Fix Eq lookup for non-primitive types
  - Remove redundant type lookup code
  - Fix generation of Doobie code with non-toplevel case classes
  - Define Read/Write instances in companion object

Story: S-24103