### PR TITLE
Fix a couple of issues with Scala query DAO support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "dotenv-cli": "^3.0.0",
-    "purescript": "^0.15.4",
+    "purescript": "0.15.2",
     "purescript-language-server": "^0.16.6",
     "purescript-psa": "^0.8.2",
     "purty": "7.0.0",

--- a/src/Ccap/Codegen/DbSupportType.purs
+++ b/src/Ccap/Codegen/DbSupportType.purs
@@ -5,7 +5,6 @@ module Ccap.Codegen.DbSupportType
   , supportTypes
   ) where
 
-import Data.Maybe (Maybe(..))
 
 type SupportType
   = { moduleName :: String
@@ -29,9 +28,9 @@ type DbSupportType
   = { dataType :: String
     , instances ::
         { equal :: String
-        , get :: Maybe String
         , meta :: String
         }
+    , catsSupportsEq :: Boolean
     , moduleName :: String
     , typeName :: String
     , underlyingSqlType :: String
@@ -43,50 +42,50 @@ dbSupportTypes =
     , instances:
         { equal: "gov.wicourts.common.instances.dates.localDateEqual"
         , meta: "gov.wicourts.common.Meta.metaLocalDate"
-        , get: Nothing
         }
     , moduleName: "DateTimeSupport"
     , typeName: "Date"
     , underlyingSqlType: "date"
+    , catsSupportsEq: false
     }
   , { dataType: "interval"
     , instances:
         { equal: "gov.wicourts.jsoncommon.data.DurationWithLife.Duration.eqDuration"
-        , get: Nothing
         , meta: "gov.wicourts.jsoncommon.data.DurationWithLife.Duration.metaDuration"
         }
     , moduleName: "DateTimeSupport"
     , typeName: "Duration"
     , underlyingSqlType: "interval"
+    , catsSupportsEq: false
     }
   , { dataType: "time without time zone"
     , instances:
         { equal: "gov.wicourts.common.instances.times.equalLocalTime"
-        , get: Nothing
         , meta: "gov.wicourts.common.Meta.metaLocalTime"
         }
     , moduleName: "DateTimeSupport"
     , typeName: "Time"
     , underlyingSqlType: "time"
+    , catsSupportsEq: false
     }
   , { dataType: "timestamp with time zone"
     , instances:
         { equal: "gov.wicourts.common.instances.dates.localDateTimeEqual"
-        , get: Nothing
         , meta: "gov.wicourts.common.Meta.metaLocalDateTime"
         }
     , moduleName: "DateTimeSupport"
     , typeName: "Timestamp"
     , underlyingSqlType: "timestamp"
+    , catsSupportsEq: false
     }
   , { dataType: "uuid"
     , instances:
         { equal: "gov.wicourts.common.instances.uuid.equalUUID"
-        , get: Just "gov.wicourts.common.instances.uuid.getUUID"
         , meta: "gov.wicourts.common.Meta.metaUuid"
         }
     , moduleName: "UUIDSupport"
     , typeName: "UUID"
     , underlyingSqlType: "uuid"
+    , catsSupportsEq: true
     }
   ]


### PR DESCRIPTION
  - Fix implicit doobie.Read instance summoning
  - Always treat xmin and ctid as separate columns
  - Remove Write instances (which will be invalid if there are any dbManaged columns)
  - Fix import handling of imports required for Read instance resolution
  - Generate primary key columns separately